### PR TITLE
ci: add GoReleaser release pipeline (brew, scoop, AUR, Gemfury, npm)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
 
       - uses: goreleaser/goreleaser-action@v6
         with:
+          distribution: goreleaser
           version: "~> v2"
           args: release --clean
         env:
@@ -40,20 +41,27 @@ jobs:
   npm:
     needs: goreleaser
     runs-on: ubuntu-latest
+    # OIDC trusted publishing: no NPM_TOKEN; npm authenticates via the OIDC
+    # id-token GitHub mints for this job.
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: "https://registry.npmjs.org"
 
+      # Trusted publishing (OIDC) needs npm >= 11.5.1; node 22 ships an older one.
+      - run: npm install -g npm@latest
+
       # Match the package version to the release tag, then publish. The wrapper
-      # downloads the matching release binary at install time.
+      # downloads the matching release binary at install time. Auth is via OIDC,
+      # so no token is needed and provenance is attached automatically.
       - name: Publish to npm
         working-directory: npm
         run: |
           npm version "${GITHUB_REF_NAME#v}" --no-git-tag-version --allow-same-version
           npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      # Zig is the cross-linker cargo-zigbuild drives; cargo-zigbuild itself is
+      # installed by GoReleaser's before-hook.
+      - uses: mlugg/setup-zig@v2
+
+      # `fury` CLI pushes the deb/rpm/apk to Gemfury (repo.aymanbagabas.com).
+      - name: Install gemfury CLI
+        run: gem install gemfury
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT with write access to homebrew-tap and scoop-bucket.
+          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+          FURY_TOKEN: ${{ secrets.FURY_TOKEN }}
+          AUR_KEY: ${{ secrets.AUR_KEY }}
+
+  npm:
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: "https://registry.npmjs.org"
+
+      # Match the package version to the release tag, then publish. The wrapper
+      # downloads the matching release binary at install time.
+      - name: Publish to npm
+        working-directory: npm
+        run: |
+          npm version "${GITHUB_REF_NAME#v}" --no-git-tag-version --allow-same-version
+          npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .DS_Store
+/dist

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,148 @@
+# GoReleaser config for drift. Builds Rust binaries with cargo-zigbuild and
+# publishes archives, checksums, Linux packages, a Homebrew formula, and a
+# Scoop manifest. Requires zig + cargo-zigbuild (installed in CI) and a
+# TAP_GITHUB_TOKEN secret with write access to the tap and bucket repos.
+version: 2
+
+project_name: drift
+
+before:
+  hooks:
+    - rustup default stable
+    - cargo install --locked cargo-zigbuild
+    # Fail fast if the tag and Cargo.toml version disagree (real releases only).
+    - >-
+      sh -c '{{ if .IsSnapshot }}true{{ else }}grep -q "^version = \"{{ .Version }}\"" Cargo.toml
+      || { echo "Cargo.toml version != tag {{ .Version }}"; exit 1; }{{ end }}'
+
+builds:
+  - id: drift
+    builder: rust
+    binary: drift
+    targets:
+      - x86_64-unknown-linux-gnu
+      - aarch64-unknown-linux-gnu
+      - x86_64-apple-darwin
+      - aarch64-apple-darwin
+      - x86_64-pc-windows-gnu
+    flags:
+      - --release
+
+archives:
+  - id: drift
+    formats: [tar.gz]
+    # Stable, predictable names so the npm wrapper can compute the download URL.
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+    files:
+      - README.md
+      - LICENSE
+      - CONFIG.md
+      - themes/*
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  use: github
+  groups:
+    - title: Features
+      regexp: '^.*?feat(\(.+\))??!?:.+$'
+      order: 0
+    - title: Bug fixes
+      regexp: '^.*?fix(\(.+\))??!?:.+$'
+      order: 1
+    - title: Others
+      order: 999
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^chore:'
+      - '^ci:'
+      - '^style:'
+      - 'Merge '
+
+nfpms:
+  - id: packages
+    package_name: drift
+    maintainer: Ayman Bagabas <ayman.bagabas@gmail.com>
+    homepage: https://github.com/aymanbagabas/drift
+    description: A standalone git diff pager for the terminal.
+    license: MIT
+    formats: [deb, rpm, apk]
+    dependencies:
+      - git
+
+# Push the Linux packages to Gemfury (serves the apt/yum repo at
+# repo.aymanbagabas.com). Requires the `fury` CLI and a FURY_TOKEN in CI.
+publishers:
+  - name: fury.io
+    ids:
+      - packages
+    dir: "{{ dir .ArtifactPath }}"
+    cmd: fury push --api-token={{ .Env.FURY_TOKEN }} {{ .ArtifactName }}
+
+brews:
+  - name: drift
+    repository:
+      owner: aymanbagabas
+      name: homebrew-tap
+      branch: master
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+    directory: "."
+    homepage: https://github.com/aymanbagabas/drift
+    description: A standalone git diff pager for the terminal.
+    license: MIT
+    dependencies:
+      - name: git
+    commit_author:
+      name: Ayman Bagabas
+      email: ayman.bagabas@gmail.com
+    test: |
+      system "#{bin}/drift", "--version"
+
+scoops:
+  - name: drift
+    repository:
+      owner: aymanbagabas
+      name: scoop-bucket
+      branch: main
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+    # Empty directory => manifest at the repo root so `scoop bucket list` sees it.
+    homepage: https://github.com/aymanbagabas/drift
+    description: A standalone git diff pager for the terminal.
+    license: MIT
+    commit_author:
+      name: Ayman Bagabas
+      email: ayman.bagabas@gmail.com
+
+aurs:
+  - name: drift-bin
+    homepage: https://github.com/aymanbagabas/drift
+    description: A standalone git diff pager for the terminal.
+    license: MIT
+    maintainers:
+      - Ayman Bagabas <ayman.bagabas@gmail.com>
+    private_key: "{{ .Env.AUR_KEY }}"
+    git_url: ssh://aur@aur.archlinux.org/drift-bin.git
+    depends:
+      - git
+    provides:
+      - drift
+    conflicts:
+      - drift
+    commit_author:
+      name: Ayman Bagabas
+      email: ayman.bagabas@gmail.com
+    package: |-
+      install -Dm755 "./drift" "${pkgdir}/usr/bin/drift"
+      install -Dm644 ./LICENSE "${pkgdir}/usr/share/licenses/drift/LICENSE"
+
+release:
+  github:
+    owner: aymanbagabas
+    name: drift

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,15 +254,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "fsevent-sys"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,7 +380,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
  "bitflags",
- "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 clap = { version = "4", features = ["derive"] }
 uncurses = "0.0.1"
 syntect = { version = "5", default-features = false, features = ["default-fancy"] }
-notify = "8"
+notify = { version = "8", default-features = false, features = ["macos_kqueue"] }
 similar = "3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/npm/bin/drift.js
+++ b/npm/bin/drift.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+// Thin launcher: exec the native drift binary that install.js placed in vendor/,
+// passing through args and the terminal so the TUI works normally.
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const binName = process.platform === "win32" ? "drift.exe" : "drift";
+const bin = path.join(__dirname, "..", "vendor", binName);
+
+const res = spawnSync(bin, process.argv.slice(2), { stdio: "inherit" });
+if (res.error) {
+  console.error(`drift: ${res.error.message}`);
+  process.exit(1);
+}
+process.exit(res.status ?? 0);

--- a/npm/install.js
+++ b/npm/install.js
@@ -1,0 +1,51 @@
+// Postinstall: download the prebuilt drift binary for this platform from the
+// matching GitHub release and unpack it into vendor/. The archive names mirror
+// the GoReleaser `archives.name_template` (drift_<version>_<os>_<arch>.<ext>).
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { execFileSync } = require("child_process");
+
+const OWNER = "aymanbagabas";
+const REPO = "drift";
+const { version } = require("./package.json");
+
+const PLATFORM = { darwin: "darwin", linux: "linux", win32: "windows" }[process.platform];
+const ARCH = { x64: "amd64", arm64: "arm64" }[process.arch];
+
+if (!PLATFORM || !ARCH) {
+  console.error(`drift: unsupported platform ${process.platform}/${process.arch}`);
+  process.exit(1);
+}
+
+const ext = PLATFORM === "windows" ? "zip" : "tar.gz";
+const asset = `${REPO}_${version}_${PLATFORM}_${ARCH}.${ext}`;
+const url = `https://github.com/${OWNER}/${REPO}/releases/download/v${version}/${asset}`;
+const binName = PLATFORM === "windows" ? "drift.exe" : "drift";
+const vendor = path.join(__dirname, "vendor");
+
+async function main() {
+  fs.mkdirSync(vendor, { recursive: true });
+  const archivePath = path.join(os.tmpdir(), asset);
+
+  const res = await fetch(url, { redirect: "follow" });
+  if (!res.ok) {
+    throw new Error(`download failed (${res.status}) for ${url}`);
+  }
+  fs.writeFileSync(archivePath, Buffer.from(await res.arrayBuffer()));
+
+  // bsdtar (macOS, Linux, Windows 10+) extracts both .tar.gz and .zip.
+  execFileSync("tar", ["-xf", archivePath, "-C", vendor, binName], { stdio: "inherit" });
+  fs.unlinkSync(archivePath);
+
+  const binPath = path.join(vendor, binName);
+  if (!fs.existsSync(binPath)) {
+    throw new Error(`binary ${binName} not found in ${asset}`);
+  }
+  if (PLATFORM !== "windows") fs.chmodSync(binPath, 0o755);
+}
+
+main().catch((err) => {
+  console.error(`drift: failed to install binary: ${err.message}`);
+  process.exit(1);
+});

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@aymanbagabas/drift",
+  "version": "0.0.0",
+  "description": "A standalone git diff pager for the terminal.",
+  "bin": {
+    "drift": "bin/drift.js"
+  },
+  "scripts": {
+    "postinstall": "node install.js"
+  },
+  "files": [
+    "bin/drift.js",
+    "install.js"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "os": [
+    "darwin",
+    "linux",
+    "win32"
+  ],
+  "cpu": [
+    "x64",
+    "arm64"
+  ],
+  "keywords": [
+    "git",
+    "diff",
+    "pager",
+    "tui",
+    "terminal"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aymanbagabas/drift.git"
+  },
+  "homepage": "https://github.com/aymanbagabas/drift#readme",
+  "license": "MIT"
+}


### PR DESCRIPTION
## What

Adds an automated, tag-triggered release pipeline built on **GoReleaser (OSS)**, cross-compiling the Rust binary with `cargo-zigbuild` and publishing to every distribution channel in one run.

### Channels
- **GitHub release** — `tar.gz`/`zip` archives + `checksums.txt` for linux, macOS, windows (x86_64 + arm64)
- **Linux packages** — `deb`/`rpm`/`apk` pushed to **Gemfury** (`repo.aymanbagabas.com`) via the OSS `publishers` section + the `fury` CLI (**not** the Pro `furies:` stanza)
- **Homebrew** — formula → [`aymanbagabas/homebrew-tap`](https://github.com/aymanbagabas/homebrew-tap) (covers macOS + Linux)
- **Scoop** — manifest → [`aymanbagabas/scoop-bucket`](https://github.com/aymanbagabas/scoop-bucket)
- **AUR** — `drift-bin` via SSH
- **npm** — wrapper `@aymanbagabas/drift` (downloads the matching release binary on install), published via **OIDC trusted publishing** (no token)

### OSS-only
`distribution: goreleaser` is pinned. Every stanza used (`builder: rust`, `archives`, `nfpms`, `publishers`, `brews`, `scoops`, `aurs`) is in the OSS schema; the Pro-only `furies:`/`npms:` are not used.

### Also
- Switches `notify` to the **`macos_kqueue`** backend. Zig ships no Apple frameworks, so FSEvents (which links CoreServices) can't cross-link for macOS; kqueue is libc-only and fine for watching git-internal files.
- Pins `archives.name_template` so the npm wrapper can predict download URLs.
- Ignores `/dist`.

## Required secrets

Add under **Settings → Secrets and variables → Actions**:

| Secret | Used for | Notes |
|--------|----------|-------|
| `TAP_GITHUB_TOKEN` | Homebrew tap + Scoop bucket | PAT with write access to both repos (built-in `GITHUB_TOKEN` can't push to other repos) |
| `FURY_TOKEN` | Gemfury push | Push token for the account behind `repo.aymanbagabas.com` |
| `AUR_KEY` | AUR push | SSH private key registered with your AUR account; the account must own/claim `drift-bin` |

npm needs **no secret** — it uses OIDC trusted publishing.

## One-time npm setup (trusted publishing)

npm won't let you attach a Trusted Publisher until the package exists, so bootstrap once:

1. Create a short-lived granular token, then publish a placeholder:
   ```sh
   cd npm && npm version 0.0.0 --no-git-tag-version && npm publish --access public
   ```
   (or `npx setup-npm-trusted-publish @aymanbagabas/drift`)
2. On npmjs.com → **package `@aymanbagabas/drift` → Settings → Trusted Publisher** → add GitHub Actions, repo `aymanbagabas/drift`, workflow `release.yml`.
3. Revoke the temporary token. All future publishes are tokenless via the `npm` job.

## Cutting a release

1. Bump the version in `Cargo.toml` (a `before` hook fails the run if the tag and `Cargo.toml` disagree).
2. Commit, then tag and push:
   ```sh
   git tag v0.1.0
   git push origin v0.1.0
   ```
3. The `release` workflow builds everything and publishes to all channels above.

## Validated locally

- `goreleaser release --snapshot` (OSS binary) builds all 5 targets, archives, deb/rpm/apk, checksums, formula, scoop manifest, and AUR PKGBUILD.
- Real `cargo-zigbuild` cross-compiles for Windows and Linux-ARM pass.
- npm wrapper: built a GoReleaser-style archive, ran the extract + shim → `drift 0.0.1`.

> Note: `brews` (formula) triggers a GoReleaser deprecation nudge toward casks. Kept intentionally — casks are macOS-only, whereas the formula also covers Homebrew on Linux and matches the existing tap. The action is pinned to `~> v2`.
