### PR TITLE
feat: pass non-diff stdin through instead of showing nothing

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -434,6 +434,39 @@ index e69de29..0cfbf08 100644\n\
     }
 
     #[test]
+    fn intraline_handles_cjk_and_accents() {
+        // Multibyte content must parse intact and word-diff on char boundaries
+        // (never byte offsets): CJK words and accented Latin, with a space so
+        // the shared prefix stays unchanged and only the last word is marked.
+        let d = "diff --git a/文書.txt b/文書.txt\n\
+index 1..2 100644\n\
+--- a/文書.txt\n\
++++ b/文書.txt\n\
+@@ -1,2 +1,2 @@\n\
+-你好 世界\n\
++你好 宇宙\n\
+-café crème\n\
++café glacé\n";
+        let files = parse(d);
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path(), "文書.txt");
+        let lines = &files[0].hunks[0].lines;
+        let cjk_add = &lines[1];
+        assert_eq!(cjk_add.content, "你好 宇宙");
+        // Segments must reassemble to the exact content — proof no multibyte
+        // char was split or dropped by the word-diff.
+        let joined: String = cjk_add.segments.iter().map(|s| s.text.as_str()).collect();
+        assert_eq!(joined, cjk_add.content);
+        assert!(cjk_add.segments.iter().any(|s| s.changed && s.text.contains("宇宙")));
+        assert!(cjk_add.segments.iter().any(|s| !s.changed && s.text.contains("你好")));
+        // Accented Latin behaves the same.
+        let acc_add = &lines[3];
+        let joined: String = acc_add.segments.iter().map(|s| s.text.as_str()).collect();
+        assert_eq!(joined, acc_add.content);
+        assert!(acc_add.segments.iter().any(|s| s.changed && s.text.contains("glacé")));
+    }
+
+    #[test]
     fn handles_new_and_binary() {
         let d = "diff --git a/a.png b/a.png\nnew file mode 100644\nindex 0..1\nBinary files /dev/null and b/a.png differ\n";
         let files = parse(d);

--- a/src/git.rs
+++ b/src/git.rs
@@ -60,6 +60,27 @@ fn git(args: &[&str]) -> std::io::Result<std::process::Output> {
     Command::new("git").args(args).output()
 }
 
+/// Peek a piped stream to decide whether it's a unified diff before the TUI
+/// takes over the terminal. Reads lines until the first `diff --git` (ANSI
+/// stripped, since git may colorize) or EOF. Returns `(is_diff, consumed)`
+/// where `consumed` is the raw bytes read: on `false`, print them straight to
+/// the terminal (it wasn't a diff, e.g. `git diff --stat`); on `true`, hand
+/// them to the streamer so the already-read prefix isn't lost.
+pub fn peek_diff<R: std::io::BufRead>(mut r: R) -> std::io::Result<(bool, String)> {
+    let mut consumed = String::new();
+    let mut line = String::new();
+    loop {
+        line.clear();
+        if r.read_line(&mut line)? == 0 {
+            return Ok((false, consumed)); // EOF before any `diff --git`.
+        }
+        consumed.push_str(&line);
+        if uncurses::ansi::strip::strip(&line).starts_with("diff --git") {
+            return Ok((true, consumed));
+        }
+    }
+}
+
 /// Resolve the repository layout for the current directory, or None if not a
 /// git repo.
 pub fn discover() -> Option<Repo> {
@@ -289,5 +310,49 @@ mod tests {
         assert!(child_diff.contains("+two"), "child missing addition:\n{child_diff}");
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// `peek_diff` recognizes a real unified diff (even colorized) and rejects
+    /// non-diff output like `git diff --stat`, returning the bytes it consumed
+    /// so the caller can pass them through untouched.
+    #[test]
+    fn peek_diff_detects_diff_vs_non_diff() {
+        // A unified diff: detected, prefix stops at the first `diff --git`.
+        let diff = b"diff --git a/f b/f\n@@ -1 +1 @@\n-a\n+b\n";
+        let (is, pre) = peek_diff(&diff[..]).unwrap();
+        assert!(is);
+        assert_eq!(pre, "diff --git a/f b/f\n");
+
+        // git show preamble before the diff: still detected; prefix carries it.
+        let show = b"commit abc\nAuthor: t\n\n    msg\n\ndiff --git a/f b/f\n@@ -1 +1 @@\n";
+        let (is, pre) = peek_diff(&show[..]).unwrap();
+        assert!(is);
+        assert!(pre.starts_with("commit abc"));
+        assert!(pre.ends_with("diff --git a/f b/f\n"));
+
+        // Non-diff (--stat): not detected; all bytes consumed for pass-through.
+        let stat = b" f | 2 +-\n 1 file changed, 1 insertion(+), 1 deletion(-)\n";
+        let (is, pre) = peek_diff(&stat[..]).unwrap();
+        assert!(!is);
+        assert_eq!(pre.as_bytes(), stat);
+
+        // Colorized `diff --git` (git's pager coloring) is still detected, and
+        // the consumed bytes keep their ANSI codes for faithful pass-through.
+        let colored = b"\x1b[1mdiff --git a/f b/f\x1b[m\n";
+        let (is, pre) = peek_diff(&colored[..]).unwrap();
+        assert!(is);
+        assert_eq!(pre.as_bytes(), colored, "ANSI codes must survive in the prefix");
+
+        // Non-diff with ANSI (e.g. colorized `--stat`): rejected, and every byte
+        // — escape codes included — is preserved so pass-through keeps color.
+        let colored_stat = b" f | 2 \x1b[32m+\x1b[m\x1b[31m-\x1b[m\n";
+        let (is, pre) = peek_diff(&colored_stat[..]).unwrap();
+        assert!(!is);
+        assert_eq!(pre.as_bytes(), colored_stat, "ANSI codes must survive pass-through");
+
+        // Empty stream: not a diff, nothing consumed.
+        let (is, pre) = peek_diff(&b""[..]).unwrap();
+        assert!(!is);
+        assert!(pre.is_empty());
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -60,25 +60,66 @@ fn git(args: &[&str]) -> std::io::Result<std::process::Output> {
     Command::new("git").args(args).output()
 }
 
+/// Bytes to buffer while classifying before giving up and treating the stream
+/// as non-diff. A real diff preamble (a `git show`/`log` header) is far under
+/// this; the cap bounds memory and latency for non-diff pager input.
+// ponytail: fixed 64 KiB cap; make it configurable only if a real preamble ever exceeds it.
+const PEEK_CAP: usize = 64 * 1024;
+
 /// Peek a piped stream to decide whether it's a unified diff before the TUI
-/// takes over the terminal. Reads lines until the first `diff --git` (ANSI
-/// stripped, since git may colorize) or EOF. Returns `(is_diff, consumed)`
-/// where `consumed` is the raw bytes read: on `false`, print them straight to
-/// the terminal (it wasn't a diff, e.g. `git diff --stat`); on `true`, hand
-/// them to the streamer so the already-read prefix isn't lost.
-pub fn peek_diff<R: std::io::BufRead>(mut r: R) -> std::io::Result<(bool, String)> {
-    let mut consumed = String::new();
-    let mut line = String::new();
+/// takes over the terminal. Reads lines until a `diff --git` header confirmed
+/// by a following git patch line (ANSI stripped, since git may colorize), EOF,
+/// or `PEEK_CAP` bytes. Returns `(is_diff, consumed)` with the raw bytes read:
+/// on `false`, write them back and stream the rest of stdin — it wasn't a diff
+/// (e.g. `git diff --stat`); on `true`, hand them to the streamer so the
+/// already-read prefix isn't lost. Bytes stay raw and are decoded lossily only
+/// for the check, so non-UTF-8 input (a legacy-encoded commit message, a binary
+/// stream) passes through instead of aborting.
+pub fn peek_diff<R: std::io::BufRead>(mut r: R) -> std::io::Result<(bool, Vec<u8>)> {
+    let mut consumed = Vec::new();
+    let mut pending_header = false; // saw `diff --git`, awaiting a continuation line
     loop {
-        line.clear();
-        if r.read_line(&mut line)? == 0 {
-            return Ok((false, consumed)); // EOF before any `diff --git`.
+        let start = consumed.len();
+        if r.read_until(b'\n', &mut consumed)? == 0 {
+            return Ok((false, consumed)); // EOF before a confirmed diff.
         }
-        consumed.push_str(&line);
-        if uncurses::ansi::strip::strip(&line).starts_with("diff --git") {
-            return Ok((true, consumed));
+        let head = strip_head(&consumed[start..]);
+        if pending_header {
+            // A real `diff --git` is always followed by an `index`/`@@`/mode/
+            // rename/binary line; plain prose that merely starts with those
+            // words won't be, so it isn't misrouted into the TUI.
+            if is_diff_continuation(&head) {
+                return Ok((true, consumed));
+            }
+            pending_header = false; // false alarm — keep scanning.
+        }
+        if head.starts_with("diff --git") {
+            pending_header = true;
+        }
+        if consumed.len() >= PEEK_CAP {
+            return Ok((false, consumed)); // too much preamble: treat as non-diff.
         }
     }
+}
+
+/// The ANSI-stripped first 64 chars of a line — enough to see any git header
+/// marker without running the stripper over a pathologically long line.
+fn strip_head(raw: &[u8]) -> String {
+    let text = String::from_utf8_lossy(raw);
+    let head: String = text.chars().take(64).collect();
+    uncurses::ansi::strip::strip(&head)
+}
+
+/// Whether `head` (already ANSI-stripped) begins a line git only emits inside a
+/// real `diff --git` block, used to confirm a candidate header.
+fn is_diff_continuation(head: &str) -> bool {
+    const MARKERS: [&str; 11] = [
+        "index ", "--- ", "+++ ", "@@", "old mode ", "new mode ", "new file mode ",
+        "deleted file mode ", "similarity index ", "rename ", "copy ",
+    ];
+    head.starts_with("Binary files")
+        || head.starts_with("GIT binary patch")
+        || MARKERS.iter().any(|m| head.starts_with(m))
 }
 
 /// Resolve the repository layout for the current directory, or None if not a
@@ -312,47 +353,86 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// `peek_diff` recognizes a real unified diff (even colorized) and rejects
-    /// non-diff output like `git diff --stat`, returning the bytes it consumed
-    /// so the caller can pass them through untouched.
+    /// `peek_diff` recognizes a real unified diff (even colorized), rejects
+    /// non-diff output like `git diff --stat`, preserves bytes exactly for
+    /// pass-through (including non-UTF-8), and stops right after the header it
+    /// confirms so the streamer resumes from the next byte.
     #[test]
     fn peek_diff_detects_diff_vs_non_diff() {
-        // A unified diff: detected, prefix stops at the first `diff --git`.
+        use std::io::Read;
+
+        // A unified diff: detected once the `@@` confirms the header; the prefix
+        // carries the header *and* the confirming line, byte-for-byte.
         let diff = b"diff --git a/f b/f\n@@ -1 +1 @@\n-a\n+b\n";
         let (is, pre) = peek_diff(&diff[..]).unwrap();
         assert!(is);
-        assert_eq!(pre, "diff --git a/f b/f\n");
+        assert_eq!(pre.as_slice(), &b"diff --git a/f b/f\n@@ -1 +1 @@\n"[..]);
 
-        // git show preamble before the diff: still detected; prefix carries it.
-        let show = b"commit abc\nAuthor: t\n\n    msg\n\ndiff --git a/f b/f\n@@ -1 +1 @@\n";
-        let (is, pre) = peek_diff(&show[..]).unwrap();
+        // git show preamble before the diff: still detected; the prefix is the
+        // preamble plus header+confirmation, and peek must NOT over-consume —
+        // the streamer resumes from the very next byte of the shared stdin.
+        let show = b"commit abc\nAuthor: t\n\n    msg\n\ndiff --git a/f b/f\n@@ -1 +1 @@\n-a\n+b\n";
+        let mut rest = &show[..];
+        let (is, pre) = peek_diff(&mut rest).unwrap();
         assert!(is);
-        assert!(pre.starts_with("commit abc"));
-        assert!(pre.ends_with("diff --git a/f b/f\n"));
+        assert!(pre.starts_with(b"commit abc"));
+        assert!(pre.ends_with(b"@@ -1 +1 @@\n"));
+        let mut tail = Vec::new();
+        rest.read_to_end(&mut tail).unwrap();
+        assert_eq!(tail.as_slice(), &b"-a\n+b\n"[..], "peek must stop after the confirmation line");
 
         // Non-diff (--stat): not detected; all bytes consumed for pass-through.
         let stat = b" f | 2 +-\n 1 file changed, 1 insertion(+), 1 deletion(-)\n";
         let (is, pre) = peek_diff(&stat[..]).unwrap();
         assert!(!is);
-        assert_eq!(pre.as_bytes(), stat);
+        assert_eq!(pre.as_slice(), &stat[..]);
 
-        // Colorized `diff --git` (git's pager coloring) is still detected, and
-        // the consumed bytes keep their ANSI codes for faithful pass-through.
-        let colored = b"\x1b[1mdiff --git a/f b/f\x1b[m\n";
+        // Non-UTF-8 bytes must pass through byte-for-byte, not abort drift.
+        let bin = b"plain\xff\xfe stat bytes\n";
+        let (is, pre) = peek_diff(&bin[..]).unwrap();
+        assert!(!is, "invalid UTF-8 must not be misclassified");
+        assert_eq!(pre.as_slice(), &bin[..], "non-UTF-8 bytes must survive pass-through");
+
+        // Ordinary prose that merely contains a `diff --git ...` line is NOT a
+        // diff (no git continuation line follows) — it passes through untouched.
+        let prose = b"ordinary text\ndiff --git not actually a patch\nmore text\n";
+        let (is, pre) = peek_diff(&prose[..]).unwrap();
+        assert!(!is, "prose containing `diff --git` must not open the TUI");
+        assert_eq!(pre.as_slice(), &prose[..]);
+
+        // Combined merge diff (`diff --cc`) is passed through: the parser only
+        // splits on `diff --git`, so this is a deliberate decision, not a bug.
+        let cc = b"diff --cc f\n@@@ -1,1 -1,1 +1,1 @@@\n";
+        let (is, _) = peek_diff(&cc[..]).unwrap();
+        assert!(!is);
+
+        // Colorized `diff --git` (git's pager coloring), confirmed by `index`:
+        // detected, and the consumed bytes keep their ANSI codes.
+        let colored = b"\x1b[1mdiff --git a/f b/f\x1b[m\nindex 00..11 100644\n";
         let (is, pre) = peek_diff(&colored[..]).unwrap();
         assert!(is);
-        assert_eq!(pre.as_bytes(), colored, "ANSI codes must survive in the prefix");
+        assert_eq!(pre.as_slice(), &colored[..], "ANSI codes must survive in the prefix");
 
-        // Non-diff with ANSI (e.g. colorized `--stat`): rejected, and every byte
-        // — escape codes included — is preserved so pass-through keeps color.
+        // Non-diff with ANSI (colorized `--stat`): rejected, every byte — escape
+        // codes included — preserved so pass-through keeps color.
         let colored_stat = b" f | 2 \x1b[32m+\x1b[m\x1b[31m-\x1b[m\n";
         let (is, pre) = peek_diff(&colored_stat[..]).unwrap();
         assert!(!is);
-        assert_eq!(pre.as_bytes(), colored_stat, "ANSI codes must survive pass-through");
+        assert_eq!(pre.as_slice(), &colored_stat[..], "ANSI codes must survive pass-through");
 
         // Empty stream: not a diff, nothing consumed.
         let (is, pre) = peek_diff(&b""[..]).unwrap();
         assert!(!is);
         assert!(pre.is_empty());
+
+        // A long non-diff stream stops at the cap instead of buffering it all.
+        let mut big = Vec::new();
+        while big.len() < PEEK_CAP + 4096 {
+            big.extend_from_slice(b"just some non-diff output line\n");
+        }
+        let total = big.len();
+        let (is, pre) = peek_diff(&big[..]).unwrap();
+        assert!(!is);
+        assert!(pre.len() >= PEEK_CAP && pre.len() < total, "peek must stop at the cap");
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -425,6 +425,25 @@ mod tests {
         assert!(!is);
         assert!(pre.is_empty());
 
+        // Valid multibyte UTF-8 (CJK) non-diff output — e.g. a localized
+        // `--stat` summary under a non-English locale — passes through
+        // byte-for-byte and is not misclassified as a diff.
+        let jp = "ファイル | 2 +-\n 1 個のファイルが変更されました\n".as_bytes();
+        let (is, pre) = peek_diff(jp).unwrap();
+        assert!(!is);
+        assert_eq!(pre.as_slice(), jp);
+
+        // A real diff with CJK paths/content and a localized (CJK) commit
+        // preamble is still detected: the header tokens git emits (`diff --git`,
+        // `index`, `@@`) are plumbing and never localized, so classification is
+        // charset- and locale-independent.
+        let cjk_diff =
+            "コミット abc\n作者: 田中\n\ndiff --git a/文書.txt b/文書.txt\nindex 1..2 100644\n@@ -1 +1 @@\n-你好世界\n+你好宇宙\n"
+                .as_bytes();
+        let (is, pre) = peek_diff(cjk_diff).unwrap();
+        assert!(is);
+        assert!(pre.ends_with("index 1..2 100644\n".as_bytes()));
+
         // A long non-diff stream stops at the cap instead of buffering it all.
         let mut big = Vec::new();
         while big.len() < PEEK_CAP + 4096 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,7 +157,9 @@ fn run() -> std::io::Result<()> {
     };
     let _ = &watcher_guard;
 
-    let mut app = tui::App::new(cfg, source, opts)?;
+    let Some(mut app) = tui::App::new(cfg, source, opts)? else {
+        return Ok(()); // stdin wasn't a diff: peek printed it and bailed.
+    };
     let result = app.run(refresh, cli.watch, Duration::from_millis(cli.poll_interval));
     app.finish()?;
     result

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -708,6 +708,10 @@ pub struct App {
     /// (instead of blocking on EOF) and sends each finished file's parsed form,
     /// raw patch, and built rows. `None` for non-stdin sources and once done.
     stream: Option<Receiver<StreamItem>>,
+    /// Stdin bytes already read by the pre-screen peek (`peek_diff`): the diff
+    /// prefix the streamer must process before continuing to read stdin, so no
+    /// input is lost. Taken by `spawn_stream`; `None` for non-stdin sources.
+    stream_prefix: Option<String>,
     /// True while `stream` is still delivering files, for the loading indicator.
     loading: bool,
     /// In-flight async worktree poll: a background thread running the diff so
@@ -797,7 +801,23 @@ pub struct App {
 }
 
 impl App {
-    pub fn new(config: Config, source: Source, opts: crate::git::Opts) -> io::Result<Self> {
+    pub fn new(config: Config, source: Source, opts: crate::git::Opts) -> io::Result<Option<Self>> {
+        // Peek a piped stream BEFORE touching the terminal: if it never produces
+        // a `diff --git` (e.g. `git diff --stat`, `git show -s`), print it back
+        // verbatim and bail — the screen is never opened, so no altscreen and no
+        // raw mode. A real diff hands its already-read prefix to the streamer.
+        let stream_prefix = if matches!(source, Source::Stdin) {
+            use std::io::Write;
+            match crate::git::peek_diff(std::io::stdin().lock())? {
+                (false, raw) => {
+                    std::io::stdout().write_all(raw.as_bytes())?;
+                    return Ok(None);
+                }
+                (true, prefix) => Some(prefix),
+            }
+        } else {
+            None
+        };
         let highlighter = Arc::new(Highlighter::new(&config.theme, config.syntax_enabled()));
         let theme = Theme::from_config(&config);
         // Read input/output from the controlling terminal (/dev/tty) so the
@@ -832,6 +852,7 @@ impl App {
             file_starts: Vec::new(),
             prefetch: None,
             stream: None,
+            stream_prefix,
             loading: false,
             poll_worker: None,
             rebuild_worker: None,
@@ -870,7 +891,7 @@ impl App {
             esc_taps: (0, None),
         };
         app.start();
-        Ok(app)
+        Ok(Some(app))
     }
 
     /// Initial load used at startup. For a piped diff (pager mode) this streams
@@ -911,6 +932,9 @@ impl App {
         let hl = Arc::clone(&self.highlighter);
         let intraline = self.config.intraline_enabled();
         let tab = self.config.tab_width;
+        // Lines already read by the pre-screen peek (the diff prefix). The worker
+        // replays them first, then continues from stdin's shared buffer.
+        let prefix = self.stream_prefix.take().unwrap_or_default();
         let (tx, rx) = channel::<StreamItem>();
         self.loading = true;
         std::thread::spawn(move || {
@@ -923,7 +947,11 @@ impl App {
                 tx.send(StreamItem { file, raw: block.to_string(), rows }).is_ok()
             };
             let mut block = String::new();
-            for line in std::io::stdin().lock().lines() {
+            // The peeked prefix already had ANSI stripped for detection but is
+            // kept raw for pass-through; strip again here so parsing sees plain
+            // text (idempotent on already-plain lines). Chained ahead of stdin.
+            let prefix_lines = prefix.lines().map(|s| Ok(s.to_string()));
+            for line in prefix_lines.chain(std::io::stdin().lock().lines()) {
                 let Ok(line) = line else { break };
                 // Git colorizes diffs it pipes to a pager; strip per line so the
                 // parser sees plain text (codes never span lines).

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2566,7 +2566,10 @@ impl App {
         let sw = self.sidebar_w();
         let bx = self.body_x();
         let bw = w.saturating_sub(sw);
-        let empty = self.files.is_empty();
+        // A piped diff still streaming its first file is loading, not idle:
+        // peek already confirmed a `diff --git` is coming, so don't flash the
+        // mascot in the gap before the first file paints.
+        let empty = self.files.is_empty() && self.stream.is_none();
         if empty {
             // Body is blank; the mascot is painted last, above everything.
         } else if self.split {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -711,7 +711,7 @@ pub struct App {
     /// Stdin bytes already read by the pre-screen peek (`peek_diff`): the diff
     /// prefix the streamer must process before continuing to read stdin, so no
     /// input is lost. Taken by `spawn_stream`; `None` for non-stdin sources.
-    stream_prefix: Option<String>,
+    stream_prefix: Option<Vec<u8>>,
     /// True while `stream` is still delivering files, for the loading indicator.
     loading: bool,
     /// In-flight async worktree poll: a background thread running the diff so
@@ -810,7 +810,13 @@ impl App {
             use std::io::Write;
             match crate::git::peek_diff(std::io::stdin().lock())? {
                 (false, raw) => {
-                    std::io::stdout().write_all(raw.as_bytes())?;
+                    // Not a diff (e.g. `git diff --stat`): write what we read,
+                    // then stream the rest straight through like `less` — the
+                    // screen is never opened, so no altscreen and no raw mode.
+                    let mut out = std::io::stdout().lock();
+                    out.write_all(&raw)?;
+                    std::io::copy(&mut std::io::stdin().lock(), &mut out)?;
+                    out.flush()?;
                     return Ok(None);
                 }
                 (true, prefix) => Some(prefix),
@@ -935,6 +941,9 @@ impl App {
         // Lines already read by the pre-screen peek (the diff prefix). The worker
         // replays them first, then continues from stdin's shared buffer.
         let prefix = self.stream_prefix.take().unwrap_or_default();
+        // The peek kept bytes raw for pass-through; decode lossily for parsing
+        // (U+FFFD here only affects rendering, never the pass-through path).
+        let prefix = String::from_utf8_lossy(&prefix).into_owned();
         let (tx, rx) = channel::<StreamItem>();
         self.loading = true;
         std::thread::spawn(move || {


### PR DESCRIPTION
## Problem

When drift is set as a git pager (`pager.diff = drift`), commands whose output isn't a unified diff produced a **blank screen**:

- `git diff --stat`, `--numstat`, `--shortstat`, `--name-only`, `--name-status`, `--check`, `--summary`
- `git show -s` (message only)

drift parsed the input to zero files and dropped you into an empty TUI (mascot), showing nothing useful.

## Fix

`git::peek_diff` inspects the piped stream **before** the terminal is touched, reading lines until the first `diff --git` (ANSI-stripped, since git colorizes for a pager) or EOF:

- **No diff** → write the consumed bytes straight back to stdout (colors preserved) and exit `Ok(None)` from `App::new` — the screen is **never opened**, so no alternate screen, no raw mode. Behaves like `less -F` / `cat` on non-pageable content.
- **Real diff** → the already-read prefix is handed to `spawn_stream`, which replays it and then continues from stdin's shared buffer, so no input is lost.

Rust's `std::io::stdin()` shares one global buffer across locks, so peeking in `App::new` and continuing to read in the streaming worker loses nothing (verified).

## Behavior

| Input | Before | After |
|-------|--------|-------|
| `git diff --stat \| drift` | blank TUI | prints stat inline, exit 0 |
| `git show -s \| drift` | blank TUI | prints message, exit 0 |
| empty pipe (no changes) | empty-screen mascot | prints nothing, exit 0 |
| real / colorized diff | pager | pager (unchanged) |

## Tests

`peek_diff_detects_diff_vs_non_diff` covers: plain diff, `git show` preamble, `--stat` (rejected), colorized `diff --git` (detected), empty stream. Full suite: 34 pass, no new clippy warnings.

## Not covered

Word-diff (`--color-words`, `--word-diff`) still enters the TUI — it emits `diff --git`, so it's detected as a diff and renders imperfectly. Separate fix.