### PR TITLE
feat(release): publish a Nix package to the NUR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,12 @@ jobs:
       # installed by GoReleaser's before-hook.
       - uses: mlugg/setup-zig@v2
 
+      # GoReleaser's `nix` publisher shells out to `nix-hash` to compute the
+      # nix-base32 archive hashes; without it on PATH the whole Nix pipe is
+      # silently skipped and no package reaches the NUR. Install Nix so the
+      # publisher runs.
+      - uses: cachix/install-nix-action@v31
+
       # `fury` CLI pushes the deb/rpm/apk to Gemfury (repo.aymanbagabas.com).
       # https://gemfury.com/guide/cli/install/
       - name: Install Gemfury CLI

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,7 +1,8 @@
 # GoReleaser config for drift. Builds Rust binaries with cargo-zigbuild and
-# publishes archives, checksums, Linux packages, a Homebrew formula, and a
-# Scoop manifest. Requires zig + cargo-zigbuild (installed in CI) and a
-# TAP_GITHUB_TOKEN secret with write access to the tap and bucket repos.
+# publishes archives, checksums, Linux packages, a Homebrew formula, a Scoop
+# manifest, and a Nix package (to the aymanbagabas/nur repo). Requires zig +
+# cargo-zigbuild (installed in CI) and a TAP_GITHUB_TOKEN secret with write
+# access to the tap, bucket, and nur repos.
 version: 2
 
 project_name: drift
@@ -128,6 +129,27 @@ scoops:
     homepage: https://github.com/aymanbagabas/drift
     description: A standalone git diff pager for the terminal.
     license: MIT
+    commit_author:
+      name: Ayman Bagabas
+      email: ayman.bagabas@gmail.com
+
+nix:
+  - name: drift
+    ids:
+      - drift
+    repository:
+      owner: aymanbagabas
+      name: nur
+      branch: master
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+    homepage: https://github.com/aymanbagabas/drift
+    description: A standalone git diff pager for the terminal.
+    license: mit
+    # `nix run` and the wrapper target this binary; `git` is a runtime dep since
+    # drift shells out to it, so makeWrapper puts it on PATH.
+    main_program: drift
+    dependencies:
+      - git
     commit_author:
       name: Ayman Bagabas
       email: ayman.bagabas@gmail.com

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,8 +1,8 @@
 # GoReleaser config for drift. Builds Rust binaries with cargo-zigbuild and
 # publishes archives, checksums, Linux packages, a Homebrew formula, a Scoop
 # manifest, and a Nix package (to the aymanbagabas/nur repo). Requires zig +
-# cargo-zigbuild (installed in CI) and a TAP_GITHUB_TOKEN secret with write
-# access to the tap, bucket, and nur repos.
+# cargo-zigbuild and nix-hash (the Nix pipe shells out to it) in CI, plus a
+# TAP_GITHUB_TOKEN secret with write access to the tap, bucket, and nur repos.
 version: 2
 
 project_name: drift

--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ sudo yum install drift
 yay -S drift-diff-bin
 ```
 
+### Nix (NUR)
+
+From the [Nix User Repositories](https://github.com/nix-community/NUR), install
+`nur.repos.aymanbagabas.drift`. Or run it ad-hoc without configuring NUR:
+
+```sh
+nix-shell -p '(import (fetchTarball "https://github.com/aymanbagabas/nur/archive/master.tar.gz") {}).drift'
+```
+
 ### Prebuilt binaries
 
 Grab an archive for your platform from the


### PR DESCRIPTION
## What

Add a `nix` block to `.goreleaser.yaml` so each release publishes a Nix package to the existing [`aymanbagabas/nur`](https://github.com/aymanbagabas/nur) repository, alongside Homebrew/Scoop/AUR/Linux packages.

## Free — no GoReleaser Pro

GoReleaser's Nix User Repository support is part of the OSS version. Only two optional sub-features are Pro-gated (`token_type` cross-SCM publishing and `pull_request.check_boxes`) — neither is used here. Verified against the [nix customization docs](https://goreleaser.com/customization/nix/).

## No workflow / toolchain changes needed

- GoReleaser computes the `nix-base32` sha256 hashes **natively** — no `nix-hash`/Nix install on the runner. Confirmed empirically: `shcopy` already publishes to this same NUR from an Ubuntu runner with no Nix step, and its NUR pin matches its latest release.
- Reuses the `TAP_GITHUB_TOKEN` already exported to the goreleaser step (same PAT that pushes to `homebrew-tap` and `scoop-bucket`). Targets the NUR default branch `master`.
- `git` is declared a runtime dependency (drift shells out to it), so `makeWrapper` puts it on PATH.

## Validation

`goreleaser check` passes — the config is valid. (The only warning is a pre-existing `brews` deprecation, unrelated to this change.)

## Follow-up (one line, after first release)

GoReleaser writes `pkgs/drift/default.nix` but does not edit the NUR repo's root `default.nix`. After the next release generates that file, add to `aymanbagabas/nur`'s `default.nix` (mirroring the existing `shcopy` entry):

```nix
drift = pkgs.callPackage ./pkgs/drift { };
```

> [!NOTE]
> Ensure `TAP_GITHUB_TOKEN` has write access to the `nur` repo. If it's a classic `repo`-scoped PAT it already does; if fine-grained, add `nur` to its repositories.
