### PR TITLE
fix(highlight): use the no-newlines syntax set to match line input

### DIFF
--- a/src/highlight.rs
+++ b/src/highlight.rs
@@ -18,7 +18,12 @@ pub struct Highlighter {
 
 impl Highlighter {
     pub fn new(theme_name: &str, enabled: bool) -> Self {
-        let syntaxes = two_face::syntax::extra_newlines();
+        // Feed lines without a trailing newline (see `FileHighlighter::line`),
+        // so use the syntax set built for that. The `_newlines` variant expects
+        // each line to end in `\n`; pairing it with newline-stripped input left
+        // newline-sensitive contexts (notably C's `#include`/preprocessor) open,
+        // which suppressed highlighting on every following line.
+        let syntaxes = two_face::syntax::extra_no_newlines();
         // The `ansi` palette holds ANSI color names (not hex) and is meant to
         // run with syntax highlighting off, so it never builds a syntect theme.
         let theme = match builtin_named(theme_name) {
@@ -157,5 +162,29 @@ mod tests {
             let colored = spans.iter().filter(|(c, _)| c.is_some()).count();
             assert!(colored > 0, "{path} produced no colored spans");
         }
+    }
+
+    /// Lines are fed without a trailing newline, so the syntax set must not be
+    /// the `_newlines` variant. With that mismatch, C's `#include` context
+    /// stayed open and flattened every following line (`int main` etc.), which
+    /// broke highlighting for whole C/H files. Distinct colors past line 1
+    /// prove the context closes.
+    #[test]
+    fn c_highlights_after_preprocessor_directive() {
+        let hl = Highlighter::new("onedark", true);
+        let mut f = hl.file("prog.c");
+        for l in ["#include <stdio.h>", ""] {
+            let _ = f.line(l);
+        }
+        let spans = f.line("int main(void) {");
+        let colors: std::collections::HashSet<String> = spans
+            .iter()
+            .filter_map(|(c, t)| c.filter(|_| !t.trim().is_empty()).map(|c| format!("{c:?}")))
+            .collect();
+        assert!(
+            colors.len() > 1,
+            "C line after #include should be highlighted, got {} color(s)",
+            colors.len()
+        );
     }
 }


### PR DESCRIPTION
## Problem

Syntax highlighting silently dropped out for whole files — most reproducibly C/H files, and worst on new files with only additions. Concrete case: `drift -A -- keyboards` on a QMK firmware tree, where every `.c`/`.h` file rendered flat below its opening `#include`.

## Root cause

drift feeds each diff line to syntect **without** a trailing newline — `str::lines()` strips it — but built its syntax set with `two_face::syntax::extra_newlines()`, whose syntaxes are compiled to expect a `\n` at the end of every line.

With that mismatch, newline-sensitive contexts never close. C's `#include` / preprocessor context stays open and suppresses the scopes on every following line, so `int main(void)`, `int count = 42;`, etc. get no color:

| syntax set | line input | `int main(void) {` |
| --- | --- | --- |
| `extra_newlines` (before) | no `\n` | **1 color — flat** |
| `extra_no_newlines` (after) | no `\n` | 4 colors ✓ |

This explains all three symptoms:
- **C especially** — its preprocessor context is newline-sensitive; Rust/TS are not, so they looked fine.
- **New files** — the whole file body follows the opening `#include`.
- **"sometimes"** — depends on whether the shown lines sit under a newline-sensitive construct.

## Fix

Use `two_face::syntax::extra_no_newlines()`, the set built for newline-stripped input — matching how `FileHighlighter::line` feeds text. One line.

## Testing

- Added a regression test (`c_highlights_after_preprocessor_directive`) asserting a C line after `#include` is highlighted; verified it **fails** on the old set and passes on the new one.
- Full suite: 41 passed.
- Verified in a live PTY: a `.c` new file now colors types, functions, numbers, and keywords correctly.
