### PR TITLE
feat(deps): upgrade uncurses to 0.0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,9 +755,9 @@ dependencies = [
 
 [[package]]
 name = "uncurses"
-version = "0.0.3"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c470d70d4b7ad3037825c73ba1c616e978484be679c6b94cd834541e4628c74a"
+checksum = "4ae7ba723f6393e94fe4d6a7687d12acf3107e2ed6ca918fa86dc7bed21e9e8a"
 dependencies = [
  "bitflags",
  "compact_str",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-uncurses = "0.0.3"
+uncurses = "0.0.5"
 syntect = { version = "5", default-features = false, features = ["default-fancy"] }
 notify = "8"
 similar = "3"

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2299,9 +2299,13 @@ impl App {
                     }
                 }
             }
-            Event::Resize(ws) => {
+            Event::Resize(_) => {
                 self.clear_sel();
-                self.program.screen_mut().resize((ws.col, ws.row));
+                // autoresize reads the size the OS already knows and repaints
+                // only when the area actually changed. Since 0.0.4 `resize`
+                // repaints unconditionally, and a terminal emits a resize report
+                // per pixel of a window drag, so route reports through this.
+                self.program.autoresize()?;
                 self.move_cursor(0);
                 self.scroll_h(0);
             }


### PR DESCRIPTION
## Summary

Upgrade `uncurses` `0.0.3 → 0.0.5`.

## Changes

- **Route `Event::Resize` through `Program::autoresize()`.** Since 0.0.4, `Screen::resize` repaints unconditionally, and a terminal emits a resize report per pixel of a window drag. `autoresize` reads the size the OS already knows (no round trip), keeps inline height, and repaints only when the area actually changed — the recommended handler per the 0.0.4 upgrade notes.

- **Scroll optimization left at its default (on).** It only engages once all of `scroll_optimize` (default on), `sync_output`, and `fullscreen` hold. `sync_output` is the gate and is only confirmed by the startup capability query; under DEC 2026 the frame is presented atomically, so the full-width scroll's corrective repaint of the fixed gutter/sidebar is never visible. Disabling it would only forfeit a real optimization (repainting a narrow fixed column beats redrawing wide rows).

## Breaking changes not affecting drift

0.0.5's breaking changes — `CursorShape` relocated to `ansi::cursor`, and continuation-cell write semantics — don't touch any API drift uses (no `CursorShape`/`CursorStyle` usage; `cell_mut` sites only restyle existing cells).

## Testing

- Builds clean; 41 tests pass.
- Verified in a live PTY: launch, render, scroll, resize (reflow to a new size), and quit all work.

Holds for the v0.0.9 release alongside #16 (syntax highlighting fix), pending the next uncurses version.
