### PR TITLE
feat(tui): render commit metadata header for a single commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Some flags worth knowing:
 | `-C`, `--directory DIR` | Run as if started in `DIR` (worktrees, bare repos) |
 | `-c`, `--config FILE` | Use a specific config file |
 | `--no-syntax` | Turn off syntax highlighting for this run |
+| `--no-commit-meta` | Collapse the commit metadata to just the commit line |
 | `-U`, `--context N` | Lines of context around each change |
 | `--ignore-whitespace` | Ignore whitespace-only changes |
 | `--diff-algorithm ALGO` | `myers`, `minimal`, `patience`, or `histogram` |
@@ -163,6 +164,7 @@ Some flags worth knowing:
 | `/` | Search the current file (regex, smart-case) |
 | `n` `N` | Next / previous match |
 | `s` | Toggle split view |
+| `c` | Expand / collapse the commit metadata (commit line always shows) |
 | `F` | File list modal |
 | `B` | Toggle the file sidebar |
 | `w` | Toggle watch mode |
@@ -185,6 +187,8 @@ drift is fully mouse-driven too:
 - Drag the sidebar's divider to resize it, live.
 - In split view, drag the divider between the two panes to rebalance them.
 - Click the `? help` badge in the status bar to toggle the help footer.
+- Double-click the commit line to expand or collapse the commit metadata; on a
+  hunk header, double-click expands the folded context.
 - Drag across the diff to select text; it lands on your system clipboard (over
   SSH too, via OSC 52). In split view the selection stays within one pane, so
   you copy just the old or just the new side.
@@ -241,6 +245,7 @@ theme         = "onedark"   # any built-in or syntect theme name
 syntax        = true        # highlight diff content
 intraline     = true        # word-level change emphasis
 line-numbers  = true        # old/new line-number gutter
+commit-meta   = true        # expand author/date/message; the commit line always shows for a single commit
 tab-width     = 4
 editor        = ""          # falls back to $VISUAL, then $EDITOR, then vi
 sidebar       = "auto"      # "auto" (opens at width >= 150), "always", or "never"

--- a/README.md
+++ b/README.md
@@ -164,14 +164,13 @@ Some flags worth knowing:
 | `/` | Search the current file (regex, smart-case) |
 | `n` `N` | Next / previous match |
 | `s` | Toggle split view |
-| `c` | Expand / collapse the commit metadata (commit line always shows) |
 | `F` | File list modal |
 | `B` | Toggle the file sidebar |
 | `w` | Toggle watch mode |
 | `V` | Start / cancel a line selection; any motion key extends it |
 | `y` | Copy the selection, or the cursor line when nothing is selected |
 | `Y` | Copy the whole current file |
-| `enter` | Expand folded context, or open the file at the cursor |
+| `enter` | On a hunk header, expand folded context; on the commit line, expand / collapse the commit metadata |
 | `v` | Open the current file in `$EDITOR` |
 | `r` | Refresh |
 | `?` | Toggle the help footer |

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,10 @@ pub struct Config {
     pub intraline: bool,
     /// Show old/new line numbers in the gutter.
     pub line_numbers: bool,
+    /// Expand the commit metadata (author, date, message) below the commit
+    /// line for a single commit. The `commit <hash>` line always shows; this
+    /// only controls the detail lines. Toggled with `c` at runtime.
+    pub commit_meta: bool,
     /// Spaces per tab when rendering.
     pub tab_width: usize,
     /// Sidebar visibility: "auto" (open when terminal >= 150 wide, default),
@@ -79,6 +83,7 @@ impl Default for Config {
             syntax: true,
             intraline: true,
             line_numbers: true,
+            commit_meta: true,
             tab_width: 4,
             sidebar: "auto".to_string(),
             sidebar_width: 30,

--- a/src/config.rs
+++ b/src/config.rs
@@ -173,6 +173,7 @@ impl Config {
                     "syntax" => self.syntax = parse_bool(val, self.syntax),
                     "intraline" => self.intraline = parse_bool(val, self.intraline),
                     "line-numbers" => self.line_numbers = parse_bool(val, self.line_numbers),
+                    "commit-meta" => self.commit_meta = parse_bool(val, self.commit_meta),
                     "tab-width" => self.tab_width = val.parse().unwrap_or(self.tab_width),
                     "sidebar" => self.sidebar = val.to_string(),
                     "sidebar-width" => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -587,6 +587,7 @@ pub fn builtin_style(theme: &str, component: &str) -> &'static str {
         "remove" => "remove",
         "context" => "context",
         "header" => "header bold",
+        "meta" => "header",
         "line-number" => "line-number",
         "statusbar" => "foreground surface",
         "statusbar-logo" => "background primary bold",

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,7 +21,8 @@ pub struct Config {
     pub line_numbers: bool,
     /// Expand the commit metadata (author, date, message) below the commit
     /// line for a single commit. The `commit <hash>` line always shows; this
-    /// only controls the detail lines. Toggled with `c` at runtime.
+    /// only controls the detail lines. Toggle at runtime with `enter` or a
+    /// double-click on the commit line.
     pub commit_meta: bool,
     /// Spaces per tab when rendering.
     pub tab_width: usize,

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -118,6 +118,24 @@ pub fn split_files(input: &str) -> Vec<String> {
     sections
 }
 
+/// Extract the commit metadata that precedes the first `diff --git` block, as
+/// produced by `git show` (commit line, author/date fields, and the indented
+/// message). Returns the raw lines with trailing blank lines trimmed. Empty
+/// when the input has no preamble (plain `git diff`, worktree/staged diffs).
+pub fn preamble(input: &str) -> Vec<String> {
+    let mut lines: Vec<String> = Vec::new();
+    for line in input.lines() {
+        if line.starts_with("diff --git") {
+            break;
+        }
+        lines.push(line.to_string());
+    }
+    while lines.last().is_some_and(|l| l.trim().is_empty()) {
+        lines.pop();
+    }
+    lines
+}
+
 /// Parse a unified diff (as produced by `git diff` / `git show`) into files.
 pub fn parse(input: &str) -> Vec<FileDiff> {
     let mut files: Vec<FileDiff> = Vec::new();
@@ -350,6 +368,22 @@ fn split_words(s: &str) -> Vec<&str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn preamble_captures_commit_header_and_drops_trailing_blanks() {
+        let show = "commit abc123\nAuthor:     A U Thor <a@u.thor>\nAuthorDate: Mon Jan 1 00:00:00 2024\n\n    Subject line\n\n    Body paragraph.\n\ndiff --git a/f b/f\nindex 1..2 100644\n--- a/f\n+++ b/f\n@@ -1 +1 @@\n-a\n+b\n";
+        let meta = preamble(show);
+        assert_eq!(meta.first().unwrap(), "commit abc123");
+        assert_eq!(meta.last().unwrap(), "    Body paragraph.");
+        assert!(meta.iter().any(|l| l == "    Subject line"));
+        // The blank lines between the message and the diff are trimmed.
+        assert!(!meta.last().unwrap().trim().is_empty());
+    }
+
+    #[test]
+    fn preamble_is_empty_for_plain_diff() {
+        assert!(preamble(SAMPLE).is_empty());
+    }
 
     const SAMPLE: &str = "diff --git a/src/main.rs b/src/main.rs\n\
 index 1234567..89abcde 100644\n\

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -122,14 +122,23 @@ pub fn split_files(input: &str) -> Vec<String> {
 /// produced by `git show` (commit line, author/date fields, and the indented
 /// message). Returns the raw lines with a single trailing blank line, so the
 /// metadata is separated from the diff below it. Empty when the input has no
-/// preamble (plain `git diff`, worktree/staged diffs).
+/// preamble (plain `git diff`, worktree/staged diffs) or no `diff --git` block
+/// at all (e.g. a combined merge diff, `diff --cc`), so non-diff output isn't
+/// mistaken for commit metadata.
 pub fn preamble(input: &str) -> Vec<String> {
     let mut lines: Vec<String> = Vec::new();
+    let mut found_diff = false;
     for line in input.lines() {
         if line.starts_with("diff --git") {
+            found_diff = true;
             break;
         }
         lines.push(line.to_string());
+    }
+    // Without a `diff --git` boundary there is no diff for these lines to
+    // precede, so don't treat them as a commit-metadata preamble.
+    if !found_diff {
+        return Vec::new();
     }
     while lines.last().is_some_and(|l| l.trim().is_empty()) {
         lines.pop();
@@ -389,6 +398,16 @@ mod tests {
     #[test]
     fn preamble_is_empty_for_plain_diff() {
         assert!(preamble(SAMPLE).is_empty());
+    }
+
+    #[test]
+    fn preamble_is_empty_without_a_diff_git_block() {
+        // A combined merge diff (`diff --cc`) has no `diff --git`; its lines
+        // must not be mistaken for commit metadata.
+        let cc = "commit abc123\nMerge: 111 222\n\n    Merge branch\n\ndiff --cc f\nindex 1,2..3\n--- a/f\n+++ b/f\n@@@ -1,1 -1,1 +1,1 @@@\n- a\n +b\n";
+        assert!(preamble(cc).is_empty());
+        // Arbitrary non-diff text is likewise not a preamble.
+        assert!(preamble("just some text\nwith no diff\n").is_empty());
     }
 
     const SAMPLE: &str = "diff --git a/src/main.rs b/src/main.rs\n\

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -120,8 +120,9 @@ pub fn split_files(input: &str) -> Vec<String> {
 
 /// Extract the commit metadata that precedes the first `diff --git` block, as
 /// produced by `git show` (commit line, author/date fields, and the indented
-/// message). Returns the raw lines with trailing blank lines trimmed. Empty
-/// when the input has no preamble (plain `git diff`, worktree/staged diffs).
+/// message). Returns the raw lines with a single trailing blank line, so the
+/// metadata is separated from the diff below it. Empty when the input has no
+/// preamble (plain `git diff`, worktree/staged diffs).
 pub fn preamble(input: &str) -> Vec<String> {
     let mut lines: Vec<String> = Vec::new();
     for line in input.lines() {
@@ -132,6 +133,10 @@ pub fn preamble(input: &str) -> Vec<String> {
     }
     while lines.last().is_some_and(|l| l.trim().is_empty()) {
         lines.pop();
+    }
+    // Keep one trailing blank as a separator before the diff.
+    if !lines.is_empty() {
+        lines.push(String::new());
     }
     lines
 }
@@ -370,14 +375,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn preamble_captures_commit_header_and_drops_trailing_blanks() {
-        let show = "commit abc123\nAuthor:     A U Thor <a@u.thor>\nAuthorDate: Mon Jan 1 00:00:00 2024\n\n    Subject line\n\n    Body paragraph.\n\ndiff --git a/f b/f\nindex 1..2 100644\n--- a/f\n+++ b/f\n@@ -1 +1 @@\n-a\n+b\n";
+    fn preamble_captures_header_and_ends_with_one_blank() {
+        let show = "commit abc123\nAuthor:     A U Thor <a@u.thor>\nAuthorDate: Mon Jan 1 00:00:00 2024\n\n    Subject line\n\n    Body paragraph.\n\n\ndiff --git a/f b/f\nindex 1..2 100644\n--- a/f\n+++ b/f\n@@ -1 +1 @@\n-a\n+b\n";
         let meta = preamble(show);
         assert_eq!(meta.first().unwrap(), "commit abc123");
-        assert_eq!(meta.last().unwrap(), "    Body paragraph.");
         assert!(meta.iter().any(|l| l == "    Subject line"));
-        // The blank lines between the message and the diff are trimmed.
-        assert!(!meta.last().unwrap().trim().is_empty());
+        assert!(meta.iter().any(|l| l == "    Body paragraph."));
+        // Multiple trailing blanks collapse to exactly one separator line.
+        assert_eq!(meta.last().unwrap(), "");
+        assert_ne!(meta[meta.len() - 2], "");
     }
 
     #[test]

--- a/src/git.rs
+++ b/src/git.rs
@@ -193,7 +193,8 @@ impl Source {
                     a.extend(["diff", "--no-color", "--no-ext-diff"].map(String::from));
                 } else {
                     a.extend(
-                        ["show", "--no-color", "--no-ext-diff", "--format=fuller"].map(String::from),
+                        ["show", "--no-color", "--no-ext-diff", "--decorate", "--format=fuller"]
+                            .map(String::from),
                     );
                 }
                 a.extend(opts.flags());
@@ -349,6 +350,8 @@ mod tests {
         let child_diff = diff_of(&child);
         assert!(child_diff.contains("-one"), "child missing removal:\n{child_diff}");
         assert!(child_diff.contains("+two"), "child missing addition:\n{child_diff}");
+        // The commit header carries ref decorations (child is at HEAD).
+        assert!(child_diff.contains("(HEAD"), "child missing ref decoration:\n{child_diff}");
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,8 @@ struct Cli {
     no_syntax: bool,
 
     /// Collapse the commit metadata to just the commit line by default (the
-    /// author, date, and message stay hidden until you expand with `c`).
+    /// author, date, and message stay hidden until you expand it — `enter` or
+    /// a double-click on the commit line).
     #[arg(long = "no-commit-meta")]
     no_commit_meta: bool,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,11 @@ struct Cli {
     #[arg(long)]
     no_syntax: bool,
 
+    /// Collapse the commit metadata to just the commit line by default (the
+    /// author, date, and message stay hidden until you expand with `c`).
+    #[arg(long = "no-commit-meta")]
+    no_commit_meta: bool,
+
     /// Ignore whitespace-only changes (git `-w`).
     #[arg(long = "ignore-whitespace")]
     ignore_whitespace: bool,
@@ -99,6 +104,9 @@ fn run() -> std::io::Result<()> {
     let mut cfg = Config::load(config_path.as_deref());
     if cli.no_syntax {
         cfg.syntax = false;
+    }
+    if cli.no_commit_meta {
+        cfg.commit_meta = false;
     }
 
     // Pager mode: a diff piped on stdin, with no explicit git selection.

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -3539,10 +3539,11 @@ fn file_of_row(starts: &[usize], row: usize) -> usize {
     starts.partition_point(|&s| s <= row).saturating_sub(1)
 }
 
-/// Document rows to pin at the top of the body for a given `scroll`: the
-/// enclosing file header and the current hunk header, but only once they've
-/// scrolled strictly above the top content line (so a header still naturally on
-/// screen isn't duplicated). Capped so at least one content row remains.
+/// Document rows to pin at the top of the body for a given `scroll`: the commit
+/// line (for a single commit), the enclosing file header, and the current hunk
+/// header, but only once they've scrolled strictly above the top content line
+/// (so a header still naturally on screen isn't duplicated). Capped so at least
+/// one content row remains.
 fn sticky_at(
     kinds: &[RowKind],
     file_starts: &[usize],
@@ -3553,8 +3554,13 @@ fn sticky_at(
         return Vec::new();
     }
     let mut out = Vec::new();
+    // The commit line pins above the file/hunk headers, so which commit you are
+    // viewing stays visible (and identifiable) while scrolling through its diff.
+    if kinds.first() == Some(&RowKind::CommitLine) {
+        out.push(0);
+    }
     let fi = file_starts.get(file_of_row(file_starts, scroll)).copied().unwrap_or(0);
-    if fi < scroll {
+    if fi < scroll && !out.contains(&fi) {
         out.push(fi);
     }
     // The hunk to pin is the one whose body contains the top line. If the top
@@ -4105,6 +4111,24 @@ mod tests {
         // A cramped body keeps at least one content row (cap = body_h - 1).
         assert_eq!(sticky_at(&kinds, &starts, 6, 2), vec![0]);
         assert_eq!(sticky_at(&kinds, &starts, 6, 1), Vec::<usize>::new());
+    }
+
+    #[test]
+    fn sticky_at_pins_commit_line_above_file_and_hunk() {
+        use super::{sticky_at, RowKind::*};
+        // A single commit: commit line, one detail line and a blank separator,
+        // then the file's header, hunk, and lines.
+        let kinds = [CommitLine, Meta, Meta, File, Hunk, Context, Context, Context];
+        let starts = [3usize];
+        let big = 100;
+        // Scrolled into the diff: the commit line pins first, then the file and
+        // hunk headers.
+        assert_eq!(sticky_at(&kinds, &starts, 6, big), vec![0, 3, 4]);
+        // Scrolled only within the metadata (top line is a detail row): just the
+        // commit line pins; the file header is still below the top.
+        assert_eq!(sticky_at(&kinds, &starts, 2, big), vec![0]);
+        // The cap still leaves a content row.
+        assert_eq!(sticky_at(&kinds, &starts, 6, 2), vec![0]);
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -138,6 +138,13 @@ enum RowKind {
     Remove,
     Context,
     Note,
+    /// The `commit <hash>` line: always shown (when a commit is present) and
+    /// bold, like the `diff --git` file header. Acts as the expand/collapse
+    /// handle for the rest of the metadata.
+    CommitLine,
+    /// A commit-metadata detail line (author, date, message) shown below the
+    /// commit line when expanded.
+    Meta,
 }
 
 /// Which top-level view is showing.
@@ -697,6 +704,13 @@ pub struct App {
     opts: crate::git::Opts,
     toplevel: Option<PathBuf>,
     files: Vec<FileDiff>,
+    /// Commit metadata lines (the `git show` header: hash, author, date, and
+    /// message) that precede the diff, captured from the source's preamble.
+    /// Empty for worktree/staged diffs and plain `git diff` input.
+    commit_meta: Vec<String>,
+    /// Whether the commit metadata header is shown; toggled with `c`, seeded
+    /// from `config.commit_meta`.
+    show_meta: bool,
     /// The raw unified-diff text for each file, in the same order as `files`,
     /// so `Y` can copy an exact per-file patch without reconstructing it.
     raw_files: Vec<String>,
@@ -856,6 +870,7 @@ impl App {
         // Enable mouse now rather than waiting for the capability-query reply,
         // so clicks and wheel work immediately (and in non-interactive tests).
         program.enable_mouse(MouseTracking::empty())?;
+        let show_meta = config.commit_meta;
         let mut app = App {
             program,
             config,
@@ -865,6 +880,8 @@ impl App {
             opts,
             toplevel: crate::git::toplevel(),
             files: Vec::new(),
+            commit_meta: Vec::new(),
+            show_meta,
             raw_files: Vec::new(),
             doc_rows: Vec::new(),
             file_starts: Vec::new(),
@@ -921,8 +938,16 @@ impl App {
         self.scroll = 0;
         self.doc_rows.clear();
         self.file_starts.clear();
+        self.commit_meta.clear();
 
         if matches!(self.source, Source::Stdin) {
+            // The pre-screen peek already read the commit header (everything up
+            // to the first `diff --git`), so capture it from the prefix before
+            // the streamer consumes it.
+            if let Some(p) = &self.stream_prefix {
+                self.commit_meta = diff::preamble(&String::from_utf8_lossy(p));
+            }
+            self.push_meta_rows();
             self.spawn_stream();
             return;
         }
@@ -931,6 +956,7 @@ impl App {
             Ok(text) => {
                 self.files = diff::parse(&text);
                 self.raw_files = diff::split_files(&text);
+                self.commit_meta = diff::preamble(&text);
                 self.last_diff = text;
             }
             Err(_) => {
@@ -939,7 +965,97 @@ impl App {
                 self.last_diff.clear();
             }
         }
+        self.push_meta_rows();
         self.spawn_prefetch();
+    }
+
+    /// Build the commit-metadata rows and place them at the top of the document,
+    /// so the incremental file builders (`drain_prefetch` / `drain_stream`)
+    /// append the diff below them. A no-op when metadata is hidden or absent.
+    fn push_meta_rows(&mut self) {
+        // Meta rows precede the first file, so `file_starts` (pushed as
+        // `doc_rows.len()` on each drain) is offset by them automatically.
+        self.doc_rows.extend(self.meta_rows());
+    }
+
+    /// The leading commit-metadata rows: the bold `commit <hash>` line always,
+    /// plus the detail lines (author, date, message) when expanded. Empty when
+    /// there is no commit (worktree/staged diffs, plain `git diff`).
+    fn meta_rows(&self) -> Vec<Row> {
+        if self.commit_meta.is_empty() {
+            return Vec::new();
+        }
+        let meta_line = |kind: RowKind, line: &str| {
+            Row::new(
+                kind,
+                None,
+                None,
+                vec![Span {
+                    fg: None,
+                    changed: false,
+                    text: line.to_string(),
+                }],
+            )
+        };
+        let mut rows = vec![meta_line(RowKind::CommitLine, &self.commit_meta[0])];
+        if self.show_meta {
+            for line in &self.commit_meta[1..] {
+                rows.push(meta_line(RowKind::Meta, line));
+            }
+        }
+        rows
+    }
+
+    /// Number of leading metadata rows currently in the document: the always-on
+    /// commit line, plus the detail lines when expanded.
+    fn meta_len(&self) -> usize {
+        if self.commit_meta.is_empty() {
+            0
+        } else if self.show_meta {
+            self.commit_meta.len()
+        } else {
+            1
+        }
+    }
+
+    /// Expand or collapse the commit-metadata detail lines in place. The commit
+    /// line always stays; this swaps the leading meta rows and shifts
+    /// `file_starts`, cursor, and scroll — no re-highlighting.
+    fn toggle_meta(&mut self) {
+        // Nothing to expand when there is only the commit line (or no commit).
+        if self.commit_meta.len() <= 1 {
+            return;
+        }
+        let old = self.meta_len();
+        self.show_meta = !self.show_meta;
+        let rows = self.meta_rows();
+        let new = rows.len();
+        self.doc_rows.splice(0..old, rows);
+        let delta = new as isize - old as isize;
+        let shift = |i: usize| -> usize {
+            if i >= old {
+                (i as isize + delta).max(0) as usize
+            } else {
+                // Inside the old meta region: clamp to the last surviving meta row.
+                i.min(new.saturating_sub(1))
+            }
+        };
+        for s in &mut self.file_starts {
+            *s = shift(*s);
+        }
+        self.cursor = shift(self.cursor);
+        self.scroll = shift(self.scroll);
+        self.move_cursor(0);
+        self.program.screen_mut().invalidate();
+    }
+
+    /// Whether the cursor sits on a commit-metadata row (the commit line or a
+    /// detail line), for the click/enter expand gesture.
+    fn on_commit_meta(&self) -> bool {
+        matches!(
+            self.doc_rows.get(self.cursor).map(|r| r.kind),
+            Some(RowKind::CommitLine) | Some(RowKind::Meta)
+        )
     }
 
     /// Stream a piped diff from stdin, emitting each file as its `diff --git`
@@ -1129,6 +1245,7 @@ impl App {
         // land after the swap.
         self.prefetch = None;
         self.last_diff = text.clone();
+        self.commit_meta = diff::preamble(&text);
         let hl = Arc::clone(&self.highlighter);
         let intraline = self.config.intraline_enabled();
         let tab = self.config.tab_width;
@@ -1159,8 +1276,14 @@ impl App {
                 let anchor = self.capture_anchor();
                 self.files = r.files;
                 self.raw_files = r.raw;
-                self.doc_rows = r.doc;
-                self.file_starts = r.starts;
+                // Prepend the commit-metadata rows (built on the main thread;
+                // the worker only assembles file rows), shifting file starts.
+                let meta = self.meta_rows();
+                let offset = meta.len();
+                let mut doc = meta;
+                doc.extend(r.doc);
+                self.doc_rows = doc;
+                self.file_starts = r.starts.iter().map(|s| s + offset).collect();
                 let row = self.resolve_anchor(&anchor);
                 self.cursor = row;
                 self.scroll = row.saturating_sub(anchor.screen_off);
@@ -1317,6 +1440,7 @@ impl App {
             ("/", "search"),
             ("n/N", "next/prev match"),
             ("s", "split view"),
+            ("c", "commit info"),
             ("F", "files"),
             ("B", "sidebar"),
             ("w", "watch on/off"),
@@ -1332,6 +1456,7 @@ impl App {
         ]
         .into_iter()
         .filter(|(k, _)| !(piped && matches!(*k, "w" | "a" | "enter" | "r")))
+        .filter(|(k, _)| !(*k == "c" && self.commit_meta.len() <= 1))
         .collect()
     }
 
@@ -1587,7 +1712,7 @@ impl App {
         let bx = self.body_x();
         match pane {
             None => (bx, self.content_start(kind, Gut::Both)),
-            Some(_) if matches!(kind, RowKind::Hunk | RowKind::Note | RowKind::File) => {
+            Some(_) if matches!(kind, RowKind::Hunk | RowKind::Note | RowKind::File | RowKind::Meta | RowKind::CommitLine) => {
                 (bx, self.content_start(kind, Gut::Both))
             }
             Some(Pane::Left) => (bx, self.content_start(kind, Gut::Old)),
@@ -1606,11 +1731,11 @@ impl App {
             None => true,
             Some(Pane::Left) => matches!(
                 kind,
-                RowKind::Context | RowKind::Remove | RowKind::Hunk | RowKind::Note | RowKind::File
+                RowKind::Context | RowKind::Remove | RowKind::Hunk | RowKind::Note | RowKind::File | RowKind::Meta | RowKind::CommitLine
             ),
             Some(Pane::Right) => matches!(
                 kind,
-                RowKind::Context | RowKind::Add | RowKind::Hunk | RowKind::Note | RowKind::File
+                RowKind::Context | RowKind::Add | RowKind::Hunk | RowKind::Note | RowKind::File | RowKind::Meta | RowKind::CommitLine
             ),
         }
     }
@@ -2080,6 +2205,12 @@ impl App {
                     self.select_file(-1);
                 } else if k.matches("s") {
                     self.split = !self.split;
+                } else if k.matches("c") {
+                    // Show/hide the commit-metadata header. A no-op when there
+                    // is no metadata (worktree/staged diffs, plain `git diff`).
+                    if !self.commit_meta.is_empty() {
+                        self.toggle_meta();
+                    }
                 } else if k.matches("F") {
                     self.view = View::Stat;
                 } else if k.matches("B") {
@@ -2110,9 +2241,12 @@ impl App {
                 } else if k.matches("v") {
                     self.open_editor()?;
                 } else if k.matches("enter") {
-                    // Enter expands folded context on a hunk header; it no
-                    // longer opens the editor (use `v` for that).
-                    if self.on_hunk() && !matches!(self.source, Source::Stdin) {
+                    // Enter expands folded context on a hunk header, or the
+                    // commit metadata on the commit line; it no longer opens
+                    // the editor (use `v` for that).
+                    if self.on_commit_meta() {
+                        self.toggle_meta();
+                    } else if self.on_hunk() && !matches!(self.source, Source::Stdin) {
                         self.expand_here();
                     }
                 } else if k.matches("r") {
@@ -2218,7 +2352,14 @@ impl App {
                                 && now.duration_since(t) < Duration::from_millis(400)
                         });
                         self.last_click = Some((now, m.x, m.y));
-                        if dbl && self.on_hunk() && !matches!(self.source, Source::Stdin) {
+                        if dbl && self.on_commit_meta() {
+                            // Double-click the commit line (or its detail lines)
+                            // to expand/collapse the metadata, like double-click
+                            // to expand context. Works for piped `git show` too.
+                            self.clear_sel();
+                            self.last_click = None;
+                            self.toggle_meta();
+                        } else if dbl && self.on_hunk() && !matches!(self.source, Source::Stdin) {
                             self.clear_sel();
                             self.last_click = None;
                             self.expand_here();
@@ -3082,7 +3223,7 @@ impl App {
         match kind {
             RowKind::Add => self.theme.add_line_bg,
             RowKind::Remove => self.theme.remove_line_bg,
-            RowKind::Hunk | RowKind::File => self.theme.header_bg,
+            RowKind::Hunk | RowKind::File | RowKind::Meta | RowKind::CommitLine => self.theme.header_bg,
             RowKind::Context | RowKind::Note => None,
         }
     }
@@ -3145,7 +3286,7 @@ impl App {
             let cbg = is_cursor.then_some(self.theme.cursor_bg);
             let bg = cbg.or(self.row_wash(r.kind));
             match r.kind {
-                RowKind::File | RowKind::Hunk | RowKind::Note => {
+                RowKind::File | RowKind::Hunk | RowKind::Note | RowKind::Meta | RowKind::CommitLine => {
                     self.draw_diff_row(r, x, width, y, bg, Gut::Both);
                     continue;
                 }
@@ -3232,6 +3373,21 @@ impl App {
                 return;
             }
             RowKind::Hunk => {
+                let (s, _) = self.slice_h(&r.spans[0].text, self.hscroll as u16, width);
+                self.program.screen_mut()
+                    .set_str((cx, y), &s, bg(self.theme.header.clone()));
+                return;
+            }
+            RowKind::CommitLine => {
+                // The commit line, always shown and bold like the file header.
+                let (s, _) = self.slice_h(&r.spans[0].text, self.hscroll as u16, width);
+                self.program.screen_mut()
+                    .set_str((cx, y), &s, bg(self.theme.header.clone().bold()));
+                return;
+            }
+            RowKind::Meta => {
+                // Same style as the diff headers, drawn full width (no gutter or
+                // sign column), so the commit header reads as one block.
                 let (s, _) = self.slice_h(&r.spans[0].text, self.hscroll as u16, width);
                 self.program.screen_mut()
                     .set_str((cx, y), &s, bg(self.theme.header.clone()));

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -712,8 +712,9 @@ pub struct App {
     /// message) that precede the diff, captured from the source's preamble.
     /// Empty for worktree/staged diffs and plain `git diff` input.
     commit_meta: Vec<String>,
-    /// Whether the commit metadata header is shown; toggled with `c`, seeded
-    /// from `config.commit_meta`.
+    /// Whether the commit metadata detail lines are expanded; the commit line
+    /// always shows. Toggled with `enter` or a double-click on the commit line,
+    /// seeded from `config.commit_meta`.
     show_meta: bool,
     /// The raw unified-diff text for each file, in the same order as `files`,
     /// so `Y` can copy an exact per-file patch without reconstructing it.
@@ -979,7 +980,8 @@ impl App {
 
     /// Build the commit-metadata rows and place them at the top of the document,
     /// so the incremental file builders (`drain_prefetch` / `drain_stream`)
-    /// append the diff below them. A no-op when metadata is hidden or absent.
+    /// append the diff below them. Adds the commit line (plus the detail lines
+    /// when expanded) for a single commit; a no-op when there is no commit.
     fn push_meta_rows(&mut self) {
         // Meta rows precede the first file, so `file_starts` (pushed as
         // `doc_rows.len()` on each drain) is offset by them automatically.

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -993,17 +993,18 @@ impl App {
         if self.commit_meta.is_empty() {
             return Vec::new();
         }
+        let tab = self.config.tab_width;
         let meta_line = |kind: RowKind, line: &str| {
-            Row::new(
-                kind,
-                None,
-                None,
-                vec![Span {
-                    fg: None,
-                    changed: false,
-                    text: line.to_string(),
-                }],
-            )
+            let mut spans = vec![Span {
+                fg: None,
+                changed: false,
+                text: line.to_string(),
+            }];
+            // Expand tabs like diff content does, so a tab in a commit message
+            // renders and measures correctly instead of writing a raw `\t` that
+            // desyncs the cell/column model.
+            expand_tabs(&mut spans, tab);
+            Row::new(kind, None, None, spans)
         };
         let mut rows = vec![meta_line(RowKind::CommitLine, &self.commit_meta[0])];
         if self.show_meta {
@@ -1886,6 +1887,14 @@ impl App {
 
     /// Open the file (and the cursor line) in the editor.
     fn open_editor(&mut self) -> io::Result<()> {
+        // A commit-metadata row has no file to open; `selected` still points at
+        // file 0, so guard against opening an arbitrary file from the header.
+        if matches!(
+            self.doc_rows.get(self.cursor).map(|r| r.kind),
+            Some(RowKind::CommitLine) | Some(RowKind::Meta)
+        ) {
+            return Ok(());
+        }
         let Some(file) = self.files.get(self.selected) else {
             return Ok(());
         };
@@ -3401,8 +3410,9 @@ impl App {
                 return;
             }
             RowKind::Meta => {
-                // Same color as the diff headers, but not bold, so only the
-                // commit line stands out. Drawn full width (no gutter or sign).
+                // Same color as the diff headers, but not bold. Like the file
+                // and hunk headers, it starts past the gutter (no line numbers
+                // or sign column), not at the far-left edge.
                 let (s, _) = self.slice_h(&r.spans[0].text, self.hscroll as u16, width);
                 self.program.screen_mut()
                     .set_str((cx, y), &s, bg(self.theme.meta.clone()));

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -34,6 +34,9 @@ struct Theme {
     remove: Style,
     context: Style,
     header: Style,
+    /// Commit metadata detail lines: the header color, but not bold, so only
+    /// the commit line stands out.
+    meta: Style,
     line_number: Style,
     add_emph_bg: Option<Color>,
     remove_emph_bg: Option<Color>,
@@ -92,6 +95,7 @@ impl Theme {
             remove: sty("remove"),
             context: sty("context"),
             header: sty("header"),
+            meta: sty("meta"),
             line_number: sty("line-number"),
             add_emph_bg: pal.color("add-emph"),
             remove_emph_bg: pal.color("remove-emph"),
@@ -3386,11 +3390,11 @@ impl App {
                 return;
             }
             RowKind::Meta => {
-                // Same style as the diff headers, drawn full width (no gutter or
-                // sign column), so the commit header reads as one block.
+                // Same color as the diff headers, but not bold, so only the
+                // commit line stands out. Drawn full width (no gutter or sign).
                 let (s, _) = self.slice_h(&r.spans[0].text, self.hscroll as u16, width);
                 self.program.screen_mut()
-                    .set_str((cx, y), &s, bg(self.theme.header.clone()));
+                    .set_str((cx, y), &s, bg(self.theme.meta.clone()));
                 return;
             }
             RowKind::Note => {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1450,12 +1450,11 @@ impl App {
             ("/", "search"),
             ("n/N", "next/prev match"),
             ("s", "split view"),
-            ("c", "commit info"),
             ("F", "files"),
             ("B", "sidebar"),
             ("w", "watch on/off"),
             ("a", "untracked on/off"),
-            ("enter", "expand context"),
+            ("enter", "expand context / commit info"),
             ("v", "edit in $EDITOR"),
             ("y", "copy line/selection"),
             ("V", "select lines"),
@@ -1465,8 +1464,20 @@ impl App {
             ("q", "quit"),
         ]
         .into_iter()
-        .filter(|(k, _)| !(piped && matches!(*k, "w" | "a" | "enter" | "r")))
-        .filter(|(k, _)| !(*k == "c" && self.commit_meta.len() <= 1))
+        .filter(|(k, _)| {
+            if piped {
+                // Repo-driven affordances are inert on a static piped diff.
+                if matches!(*k, "w" | "a" | "r") {
+                    return false;
+                }
+                // `enter` expands context (inert when piped) but also toggles
+                // commit metadata, so keep it for a piped `git show`.
+                if *k == "enter" && self.commit_meta.is_empty() {
+                    return false;
+                }
+            }
+            true
+        })
         .collect()
     }
 
@@ -2215,12 +2226,6 @@ impl App {
                     self.select_file(-1);
                 } else if k.matches("s") {
                     self.split = !self.split;
-                } else if k.matches("c") {
-                    // Show/hide the commit-metadata header. A no-op when there
-                    // is no metadata (worktree/staged diffs, plain `git diff`).
-                    if !self.commit_meta.is_empty() {
-                        self.toggle_meta();
-                    }
                 } else if k.matches("F") {
                     self.view = View::Stat;
                 } else if k.matches("B") {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -947,9 +947,13 @@ impl App {
         if matches!(self.source, Source::Stdin) {
             // The pre-screen peek already read the commit header (everything up
             // to the first `diff --git`), so capture it from the prefix before
-            // the streamer consumes it.
+            // the streamer consumes it. Git colorizes the diff it pipes to a
+            // pager, so strip ANSI first: otherwise a colorized `diff --git`
+            // line isn't recognized as the diff boundary and its escape codes
+            // leak into the "metadata".
             if let Some(p) = &self.stream_prefix {
-                self.commit_meta = diff::preamble(&String::from_utf8_lossy(p));
+                let text = uncurses::ansi::strip::strip(&String::from_utf8_lossy(p));
+                self.commit_meta = diff::preamble(&text);
             }
             self.push_meta_rows();
             self.spawn_stream();

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1015,7 +1015,8 @@ impl App {
     }
 
     /// Number of leading metadata rows currently in the document: the always-on
-    /// commit line, plus the detail lines when expanded.
+    /// commit line, plus the detail lines (and the preamble's trailing blank
+    /// separator) when expanded.
     fn meta_len(&self) -> usize {
         if self.commit_meta.is_empty() {
             0
@@ -1057,12 +1058,13 @@ impl App {
         self.program.screen_mut().invalidate();
     }
 
-    /// Whether the cursor sits on a commit-metadata row (the commit line or a
-    /// detail line), for the click/enter expand gesture.
-    fn on_commit_meta(&self) -> bool {
+    /// Whether the cursor sits on the commit line — the toggle handle for the
+    /// commit metadata. Detail lines are not handles (like a hunk header vs. its
+    /// body), so `enter` / double-click only act here.
+    fn on_commit_line(&self) -> bool {
         matches!(
             self.doc_rows.get(self.cursor).map(|r| r.kind),
-            Some(RowKind::CommitLine) | Some(RowKind::Meta)
+            Some(RowKind::CommitLine)
         )
     }
 
@@ -2252,7 +2254,7 @@ impl App {
                     // Enter expands folded context on a hunk header, or the
                     // commit metadata on the commit line; it no longer opens
                     // the editor (use `v` for that).
-                    if self.on_commit_meta() {
+                    if self.on_commit_line() {
                         self.toggle_meta();
                     } else if self.on_hunk() && !matches!(self.source, Source::Stdin) {
                         self.expand_here();
@@ -2360,10 +2362,10 @@ impl App {
                                 && now.duration_since(t) < Duration::from_millis(400)
                         });
                         self.last_click = Some((now, m.x, m.y));
-                        if dbl && self.on_commit_meta() {
-                            // Double-click the commit line (or its detail lines)
-                            // to expand/collapse the metadata, like double-click
-                            // to expand context. Works for piped `git show` too.
+                        if dbl && self.on_commit_line() {
+                            // Double-click the commit line to expand/collapse
+                            // the metadata, like double-click to expand context
+                            // on a hunk header. Works for piped `git show` too.
                             self.clear_sel();
                             self.last_click = None;
                             self.toggle_meta();


### PR DESCRIPTION
## Summary

Render a commit's metadata (hash, refs, author, date, message) at the top of the diff when viewing a single commit, styled like the diff headers.

Addresses the request in aymanbagabas/drift#1 (comment):

> I'd love to see commit metadata being rendered for `git show` when using `drift` as the pager. 😄 (Hash, title, description, date, etc.)

— https://github.com/aymanbagabas/drift/issues/1#issuecomment-5498006091

## Demo

The commit line stays pinned while scrolling; `enter` (or a double-click) on it expands/collapses the details:

![commit-meta](https://github.com/user-attachments/assets/462fc3c8-42cf-495e-b186-bfe613ed9fd3)

## What it does

- The `commit <hash>` line is **always shown** for a single commit and **bold**, like the `diff --git` file header. It also carries git's **ref decorations** — `(HEAD -> main, tag: v0.1.0, origin/main)`.
- It **pins as a sticky header** while scrolling (above the file and hunk headers), so which commit you're viewing stays visible through a long diff.
- The detail lines (author, date, message) render in the header color but **not bold**, and end with a blank separator before the diff.
- **Expand/collapse** the details with **`enter`** or a **double-click** on the commit line — the same gesture that expands folded context on a hunk header (as a pager, `g` then `enter`). Works for piped `git show` too. Toggling splices the leading rows in place, keeping the cursor put.
- Shown expanded by default; **`--no-commit-meta`** / `commit-meta = false` starts collapsed (the commit line still shows).

## Scope

Only single-commit views are affected — `drift <commit>` and piped `git show`. Worktree, `--staged`, ranges (`drift a..b`), and plain `git diff` have no commit header, so they're untouched. A log view / interleaved per-commit metadata is left for the history-browsing work in #1.

## How it works

`diff::preamble` captures the lines before the first `diff --git` (ANSI-stripped, so a colorized pager stream doesn't leak codes), taken from the peeked stdin prefix (pager mode) or the diff text (rev source). They become header-styled `RowKind::CommitLine` / `RowKind::Meta` rows ahead of the files; `file_starts` offsets and rebuilds follow automatically. `drift <commit>` runs `git show --decorate --format=fuller`.

## Testing

- Parser tests for `diff::preamble` (captures the header, ends with one blank; empty for a plain diff), a `sticky_at` test for the pinned commit line, and a ref-decoration assertion. Full suite: 44 pass.
- Verified in a live PTY: `drift <commit>`, piped `git show`, sticky commit line while scrolling, `enter`/double-click on the commit line only, refs on the commit line, `--no-commit-meta` starts collapsed, colorized `git diff | drift` no longer leaks escape codes, and worktree/staged/range/`git diff` show nothing.
- No new clippy warnings; README updated (keys, flag, config, mouse tips).
