### PR TITLE
feat(tui): show the repo directory in the window title

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2,7 +2,7 @@
 //! bottom footer, driven by an uncurses `Screen`.
 
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::mpsc::{channel, Receiver, TryRecvError};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -2748,9 +2748,13 @@ impl App {
     }
 
     fn update_title(&mut self) -> io::Result<()> {
-        let want = match self.files.get(self.selected) {
-            Some(f) => format!("{} · drift", f.path()),
-            None => "drift".to_string(),
+        let dir = self.toplevel.as_deref().map(abbrev_home);
+        let file = self.files.get(self.selected).map(|f| f.path());
+        let want = match (file, dir) {
+            (Some(f), Some(d)) => format!("{f} · {d} · drift"),
+            (Some(f), None) => format!("{f} · drift"),
+            (None, Some(d)) => format!("{d} · drift"),
+            (None, None) => "drift".to_string(),
         };
         if want != self.title {
             self.program.set_title(&want)?;
@@ -3551,6 +3555,32 @@ fn file_of_row(starts: &[usize], row: usize) -> usize {
     starts.partition_point(|&s| s <= row).saturating_sub(1)
 }
 
+/// Render a path for display, abbreviating the user's home directory to `~`
+/// (so `/Users/ayman/src/drift` shows as `~/src/drift`). Only a whole leading
+/// path component is replaced, so `/home/ayman2` is left untouched when the
+/// home directory is `/home/ayman`.
+fn abbrev_home(path: &Path) -> String {
+    abbrev_with_home(path, std::env::home_dir().as_deref())
+}
+
+fn abbrev_with_home(path: &Path, home: Option<&Path>) -> String {
+    let s = path.to_string_lossy();
+    if let Some(home) = home {
+        let home = home.to_string_lossy();
+        if !home.is_empty() {
+            if let Some(rest) = s.strip_prefix(home.as_ref()) {
+                if rest.is_empty() {
+                    return "~".to_string();
+                }
+                if rest.starts_with('/') {
+                    return format!("~{rest}");
+                }
+            }
+        }
+    }
+    s.into_owned()
+}
+
 /// Document rows to pin at the top of the body for a given `scroll`: the commit
 /// line (for a single commit), the enclosing file header, and the current hunk
 /// header, but only once they've scrolled strictly above the top content line
@@ -3897,7 +3927,7 @@ fn fit_tail(cells: &[(&str, u8)], budget: u16) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{expand_tabs, fit, fit_tail, file_of_row, match_cells, reveal, slice_cells, slice_fit, text_cells, Face, Mascot, Sel, Span, MASCOT_H, MASCOT_W};
+    use super::{expand_tabs, fit, fit_tail, file_of_row, match_cells, reveal, slice_cells, slice_fit, text_cells, abbrev_with_home, Face, Mascot, Sel, Span, MASCOT_H, MASCOT_W};
     use regex::RegexBuilder;
     use uncurses::text::{grapheme_cells, WidthMode};
 
@@ -4029,6 +4059,24 @@ mod tests {
         assert_eq!(text(&fd("old.txt", "/dev/null")), "diff --git a/old.txt b/old.txt");
         // Rename keeps both distinct paths.
         assert_eq!(text(&fd("from.txt", "to.txt")), "diff --git a/from.txt b/to.txt");
+    }
+
+    #[test]
+    fn abbrev_home_replaces_only_a_whole_home_component() {
+        let home = std::path::Path::new("/home/ayman");
+        assert_eq!(abbrev_with_home(std::path::Path::new("/home/ayman"), Some(home)), "~");
+        assert_eq!(
+            abbrev_with_home(std::path::Path::new("/home/ayman/src/drift"), Some(home)),
+            "~/src/drift"
+        );
+        // A sibling whose name merely starts with home is left untouched.
+        assert_eq!(
+            abbrev_with_home(std::path::Path::new("/home/ayman2/x"), Some(home)),
+            "/home/ayman2/x"
+        );
+        // Paths outside home, and the no-home case, are unchanged.
+        assert_eq!(abbrev_with_home(std::path::Path::new("/etc/hosts"), Some(home)), "/etc/hosts");
+        assert_eq!(abbrev_with_home(std::path::Path::new("/home/ayman"), None), "/home/ayman");
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -3570,9 +3570,16 @@ fn abbrev_with_home(path: &Path, home: Option<&Path>) -> String {
                 if rest.as_os_str().is_empty() {
                     return "~".to_string();
                 }
-                // `strip_prefix` matches whole path components, so this is the
-                // native separator on every platform (e.g. `~\src` on Windows).
-                return format!("~{}{}", std::path::MAIN_SEPARATOR, rest.display());
+                // Rebuild the tail from components so the separators are always
+                // native. `rest.display()` would preserve whatever separators
+                // the input used (Windows accepts `/` too), which could produce
+                // a mixed result like `~\src/drift`.
+                let mut out = String::from("~");
+                for comp in rest.components() {
+                    out.push(std::path::MAIN_SEPARATOR);
+                    out.push_str(&comp.as_os_str().to_string_lossy());
+                }
+                return out;
             }
         }
     }
@@ -4086,6 +4093,12 @@ mod tests {
         // The continuation uses the native separator (`\` on Windows).
         assert_eq!(
             abbrev_with_home(std::path::Path::new(r"C:\Users\ayman\src\drift"), Some(home)),
+            r"~\src\drift"
+        );
+        // Forward slashes in the input (Windows accepts them) are normalized to
+        // the native separator, never mixed.
+        assert_eq!(
+            abbrev_with_home(std::path::Path::new("C:/Users/ayman/src/drift"), Some(home)),
             r"~\src\drift"
         );
         // A sibling whose name merely starts with home is left untouched.

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -3564,21 +3564,19 @@ fn abbrev_home(path: &Path) -> String {
 }
 
 fn abbrev_with_home(path: &Path, home: Option<&Path>) -> String {
-    let s = path.to_string_lossy();
     if let Some(home) = home {
-        let home = home.to_string_lossy();
-        if !home.is_empty() {
-            if let Some(rest) = s.strip_prefix(home.as_ref()) {
-                if rest.is_empty() {
+        if !home.as_os_str().is_empty() {
+            if let Ok(rest) = path.strip_prefix(home) {
+                if rest.as_os_str().is_empty() {
                     return "~".to_string();
                 }
-                if rest.starts_with('/') {
-                    return format!("~{rest}");
-                }
+                // `strip_prefix` matches whole path components, so this is the
+                // native separator on every platform (e.g. `~\src` on Windows).
+                return format!("~{}{}", std::path::MAIN_SEPARATOR, rest.display());
             }
         }
     }
-    s.into_owned()
+    path.to_string_lossy().into_owned()
 }
 
 /// Document rows to pin at the top of the body for a given `scroll`: the commit
@@ -4061,6 +4059,7 @@ mod tests {
         assert_eq!(text(&fd("from.txt", "to.txt")), "diff --git a/from.txt b/to.txt");
     }
 
+    #[cfg(unix)]
     #[test]
     fn abbrev_home_replaces_only_a_whole_home_component() {
         let home = std::path::Path::new("/home/ayman");
@@ -4077,6 +4076,32 @@ mod tests {
         // Paths outside home, and the no-home case, are unchanged.
         assert_eq!(abbrev_with_home(std::path::Path::new("/etc/hosts"), Some(home)), "/etc/hosts");
         assert_eq!(abbrev_with_home(std::path::Path::new("/home/ayman"), None), "/home/ayman");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn abbrev_home_replaces_only_a_whole_home_component() {
+        let home = std::path::Path::new(r"C:\Users\ayman");
+        assert_eq!(abbrev_with_home(std::path::Path::new(r"C:\Users\ayman"), Some(home)), "~");
+        // The continuation uses the native separator (`\` on Windows).
+        assert_eq!(
+            abbrev_with_home(std::path::Path::new(r"C:\Users\ayman\src\drift"), Some(home)),
+            r"~\src\drift"
+        );
+        // A sibling whose name merely starts with home is left untouched.
+        assert_eq!(
+            abbrev_with_home(std::path::Path::new(r"C:\Users\ayman2\x"), Some(home)),
+            r"C:\Users\ayman2\x"
+        );
+        // Paths outside home, and the no-home case, are unchanged.
+        assert_eq!(
+            abbrev_with_home(std::path::Path::new(r"C:\Windows\System32"), Some(home)),
+            r"C:\Windows\System32"
+        );
+        assert_eq!(
+            abbrev_with_home(std::path::Path::new(r"C:\Users\ayman"), None),
+            r"C:\Users\ayman"
+        );
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -707,6 +707,10 @@ pub struct App {
     source: Source,
     opts: crate::git::Opts,
     toplevel: Option<PathBuf>,
+    /// The repo top-level, pre-abbreviated with `~`, for the window title.
+    /// `toplevel` never changes for the lifetime of the app, so this is
+    /// computed once instead of re-running `home_dir()` on every render.
+    title_dir: Option<String>,
     files: Vec<FileDiff>,
     /// Commit metadata lines (the `git show` header: hash, author, date, and
     /// message) that precede the diff, captured from the source's preamble.
@@ -876,6 +880,8 @@ impl App {
         // so clicks and wheel work immediately (and in non-interactive tests).
         program.enable_mouse(MouseTracking::empty())?;
         let show_meta = config.commit_meta;
+        let toplevel = crate::git::toplevel();
+        let title_dir = toplevel.as_deref().map(abbrev_home);
         let mut app = App {
             program,
             config,
@@ -883,7 +889,8 @@ impl App {
             highlighter,
             source,
             opts,
-            toplevel: crate::git::toplevel(),
+            toplevel,
+            title_dir,
             files: Vec::new(),
             commit_meta: Vec::new(),
             show_meta,
@@ -2748,9 +2755,8 @@ impl App {
     }
 
     fn update_title(&mut self) -> io::Result<()> {
-        let dir = self.toplevel.as_deref().map(abbrev_home);
         let file = self.files.get(self.selected).map(|f| f.path());
-        let want = match (file, dir) {
+        let want = match (file, self.title_dir.as_deref()) {
             (Some(f), Some(d)) => format!("{f} · {d} · drift"),
             (Some(f), None) => format!("{f} · drift"),
             (None, Some(d)) => format!("{d} · drift"),


### PR DESCRIPTION
Adds the git repository directory to the terminal window title, next to the current file, with the home directory abbreviated to `~`.

## What

- The title becomes `<file> · <dir> · drift`, e.g. `src/tui.rs · ~/Source/aymanbagabas/drift · drift`.
- `<dir>` is the git top-level (`git rev-parse --show-toplevel`). In pager mode (a piped diff with no repo) there is no dir, so the title stays `<file> · drift`; with no file it is `<dir> · drift`, and with neither just `drift`.
- Home is abbreviated to `~`, replacing only a whole leading path component (so `/home/ayman2` is left alone when home is `/home/ayman`).

## Home lookup

Uses `std::env::home_dir()` rather than reading `$HOME` directly. That function was un-deprecated and fixed in Rust 1.85, and it resolves `USERPROFILE` on Windows, so the `~` abbreviation is not limited to the Unix `HOME` variable.

## Tests

- Unit test `abbrev_home_replaces_only_a_whole_home_component` covers the exact-home, subpath, sibling-prefix, outside-home, and no-home cases.
- `cargo test` (46) pass; clippy unchanged.
- PTY-verified with `tui-test get title`: repo under home shows `~/…`, a repo outside home shows the full path, and pager mode shows no dir.