### PR TITLE
ci: build and test on Linux, macOS, and Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build
+        run: cargo build --locked --verbose
+
+      - name: Test
+        run: cargo test --locked --verbose


### PR DESCRIPTION
Adds a `ci` workflow that builds and runs the test suite on the three major platforms.

## What

- Matrix over `ubuntu-latest`, `macos-latest`, and `windows-latest` (`fail-fast: false`, so one platform failing still reports the others).
- Runs on every push to `main` and every pull request.
- Steps: `actions/checkout@v4` → `dtolnay/rust-toolchain@stable` → `Swatinem/rust-cache@v2` → `cargo build --locked` → `cargo test --locked`.
- `concurrency` cancels superseded runs on the same ref.

## Why

The repo previously had no test CI (only the release workflow). Building and testing on Windows guards against platform-specific bugs such as path handling that differs from Unix — e.g. the home-directory abbreviation fix in #20.

## Notes

- `cargo test` compiles first, so it also covers the build; the explicit `build` step surfaces compile errors separately for a clearer signal.
- No `cargo fmt`/`clippy` gate: the repo intentionally diverges from `rustfmt` defaults, and there are pre-existing clippy lints, so a formatting/lint gate would produce noise rather than catch regressions. This can be added later with an agreed baseline.
- Validated locally with `actionlint` (exit 0) and `cargo test --locked`.