### PR TITLE
feat(tui): gutter glyphs for foldable header lines

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -27,6 +27,10 @@ surfaces instead of silently doing nothing.
 | `intraline` | bool | `true` | Word-level change emphasis. Always off under `ansi`. |
 | `line-numbers` | bool | `true` | Show old/new line-number gutter. |
 | `tab-width` | int | `4` | Spaces per tab when rendering. |
+| `wrap-symbol` | string | `↪` | Symbol at the start of each wrapped continuation line. |
+| `expand-symbol` | string | `›` | Gutter symbol on the collapsed commit line (expand to show its metadata). |
+| `collapse-symbol` | string | `⌄` | Gutter symbol on the expanded commit line (collapse to hide its metadata). |
+| `context-symbol` | string | `⋯` | Gutter symbol on a hunk header (reveal more context). |
 | `sidebar` | string | `auto` | File-list sidebar: `auto` (open when terminal ≥ 150 wide), `always`, or `never`. The `B` key overrides at runtime. |
 | `sidebar-width` | int | `30` | Sidebar width in cells (including divider). Drag the divider to override at runtime. |
 | `sidebar-side` | string | `left` | Which side the sidebar sits on: `left` or `right`. |

--- a/README.md
+++ b/README.md
@@ -250,8 +250,9 @@ line-numbers  = true        # old/new line-number gutter
 commit-meta   = true        # expand author/date/message; the commit line always shows for a single commit
 wrap          = false       # wrap long lines instead of scrolling horizontally (toggle with w)
 wrap-symbol   = "↪"         # glyph shown at the start of each wrapped continuation line
-expand-symbol = "▸"         # gutter glyph on a foldable header you can expand (hunk / collapsed commit line)
-collapse-symbol = "▾"       # gutter glyph on an expanded header you can collapse (the commit line)
+expand-symbol = "›"         # gutter glyph on the collapsed commit line (expand to show metadata)
+collapse-symbol = "⌄"       # gutter glyph on the expanded commit line (collapse to hide metadata)
+context-symbol = "⋯"        # gutter glyph on a hunk header (reveal more context)
 tab-width     = 4
 editor        = ""          # falls back to $VISUAL, then $EDITOR, then vi
 sidebar       = "auto"      # "auto" (opens at width >= 150), "always", or "never"

--- a/README.md
+++ b/README.md
@@ -250,6 +250,8 @@ line-numbers  = true        # old/new line-number gutter
 commit-meta   = true        # expand author/date/message; the commit line always shows for a single commit
 wrap          = false       # wrap long lines instead of scrolling horizontally (toggle with w)
 wrap-symbol   = "↪"         # glyph shown at the start of each wrapped continuation line
+expand-symbol = "▸"         # gutter glyph on a foldable header you can expand (hunk / collapsed commit line)
+collapse-symbol = "▾"       # gutter glyph on an expanded header you can collapse (the commit line)
 tab-width     = 4
 editor        = ""          # falls back to $VISUAL, then $EDITOR, then vi
 sidebar       = "auto"      # "auto" (opens at width >= 150), "always", or "never"

--- a/README.md
+++ b/README.md
@@ -249,10 +249,10 @@ intraline     = true        # word-level change emphasis
 line-numbers  = true        # old/new line-number gutter
 commit-meta   = true        # expand author/date/message; the commit line always shows for a single commit
 wrap          = false       # wrap long lines instead of scrolling horizontally (toggle with w)
-wrap-symbol   = "↪"         # glyph shown at the start of each wrapped continuation line
-expand-symbol = "›"         # gutter glyph on the collapsed commit line (expand to show metadata)
-collapse-symbol = "⌄"       # gutter glyph on the expanded commit line (collapse to hide metadata)
-context-symbol = "⋯"        # gutter glyph on a hunk header (reveal more context)
+wrap-symbol   = "↪"         # symbol shown at the start of each wrapped continuation line
+expand-symbol = "›"         # gutter symbol on the collapsed commit line (expand to show metadata)
+collapse-symbol = "⌄"       # gutter symbol on the expanded commit line (collapse to hide metadata)
+context-symbol = "⋯"        # gutter symbol on a hunk header (reveal more context)
 tab-width     = 4
 editor        = ""          # falls back to $VISUAL, then $EDITOR, then vi
 sidebar       = "auto"      # "auto" (opens at width >= 150), "always", or "never"

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,12 @@ pub struct Config {
     pub wrap: bool,
     /// The glyph drawn at the start of each wrapped continuation line.
     pub wrap_symbol: String,
+    /// Gutter glyph on a foldable header that can be expanded (a hunk header,
+    /// or the collapsed commit line).
+    pub expand_symbol: String,
+    /// Gutter glyph on a header that is expanded and can be collapsed (the
+    /// commit line with its metadata showing).
+    pub collapse_symbol: String,
     /// Sidebar visibility: "auto" (open when terminal >= 150 wide, default),
     /// "always" (open), or "never" (closed). The `b` key overrides at runtime.
     pub sidebar: String,
@@ -93,6 +99,8 @@ impl Default for Config {
             tab_width: 4,
             wrap: false,
             wrap_symbol: "↪".to_string(),
+            expand_symbol: "▸".to_string(),
+            collapse_symbol: "▾".to_string(),
             sidebar: "auto".to_string(),
             sidebar_width: 30,
             sidebar_side: "left".to_string(),
@@ -184,6 +192,8 @@ impl Config {
                     "tab-width" => self.tab_width = val.parse().unwrap_or(self.tab_width),
                     "wrap" => self.wrap = parse_bool(val, self.wrap),
                     "wrap-symbol" => self.wrap_symbol = val.to_string(),
+                    "expand-symbol" => self.expand_symbol = val.to_string(),
+                    "collapse-symbol" => self.collapse_symbol = val.to_string(),
                     "sidebar" => self.sidebar = val.to_string(),
                     "sidebar-width" => {
                         self.sidebar_width = val.parse().unwrap_or(self.sidebar_width)

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,12 +31,14 @@ pub struct Config {
     pub wrap: bool,
     /// The glyph drawn at the start of each wrapped continuation line.
     pub wrap_symbol: String,
-    /// Gutter glyph on a foldable header that can be expanded (a hunk header,
-    /// or the collapsed commit line).
+    /// Gutter glyph on the collapsed commit line, which you can expand to show
+    /// its metadata.
     pub expand_symbol: String,
-    /// Gutter glyph on a header that is expanded and can be collapsed (the
-    /// commit line with its metadata showing).
+    /// Gutter glyph on the expanded commit line, which you can collapse to hide
+    /// its metadata.
     pub collapse_symbol: String,
+    /// Gutter glyph on a hunk header, marking context you can reveal.
+    pub context_symbol: String,
     /// Sidebar visibility: "auto" (open when terminal >= 150 wide, default),
     /// "always" (open), or "never" (closed). The `b` key overrides at runtime.
     pub sidebar: String,
@@ -99,8 +101,9 @@ impl Default for Config {
             tab_width: 4,
             wrap: false,
             wrap_symbol: "↪".to_string(),
-            expand_symbol: "▸".to_string(),
-            collapse_symbol: "▾".to_string(),
+            expand_symbol: "›".to_string(),
+            collapse_symbol: "⌄".to_string(),
+            context_symbol: "⋯".to_string(),
             sidebar: "auto".to_string(),
             sidebar_width: 30,
             sidebar_side: "left".to_string(),
@@ -194,6 +197,7 @@ impl Config {
                     "wrap-symbol" => self.wrap_symbol = val.to_string(),
                     "expand-symbol" => self.expand_symbol = val.to_string(),
                     "collapse-symbol" => self.collapse_symbol = val.to_string(),
+                    "context-symbol" => self.context_symbol = val.to_string(),
                     "sidebar" => self.sidebar = val.to_string(),
                     "sidebar-width" => {
                         self.sidebar_width = val.parse().unwrap_or(self.sidebar_width)

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,15 +29,15 @@ pub struct Config {
     /// Wrap long lines instead of scrolling horizontally. Toggle at runtime
     /// with `w`.
     pub wrap: bool,
-    /// The glyph drawn at the start of each wrapped continuation line.
+    /// The symbol drawn at the start of each wrapped continuation line.
     pub wrap_symbol: String,
-    /// Gutter glyph on the collapsed commit line, which you can expand to show
+    /// Gutter symbol on the collapsed commit line, which you can expand to show
     /// its metadata.
     pub expand_symbol: String,
-    /// Gutter glyph on the expanded commit line, which you can collapse to hide
+    /// Gutter symbol on the expanded commit line, which you can collapse to hide
     /// its metadata.
     pub collapse_symbol: String,
-    /// Gutter glyph on a hunk header, marking context you can reveal.
+    /// Gutter symbol on a hunk header, marking context you can reveal.
     pub context_symbol: String,
     /// Sidebar visibility: "auto" (open when terminal >= 150 wide, default),
     /// "always" (open), or "never" (closed). The `b` key overrides at runtime.

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -3901,12 +3901,31 @@ impl App {
                 return;
             }
             RowKind::Hunk => {
+                // Gutter glyph: a hunk header can always reveal more context
+                // (in a repo source). Skip it in pager mode, where there's no
+                // repo to expand against.
+                if seg == 0 && num_w >= 2 && !matches!(self.source, Source::Stdin) {
+                    let g = self.config.expand_symbol.clone();
+                    self.program.screen_mut()
+                        .set_str((x + num_w - 2, y), &g, bg(self.theme.line_number.clone()));
+                }
                 let (s, _) = self.slice_h(&r.spans[0].text, self.hscroll as u16, width);
                 self.program.screen_mut()
                     .set_str((cx, y), &s, bg(self.theme.header.clone()));
                 return;
             }
             RowKind::CommitLine => {
+                // Gutter glyph: the commit line folds its metadata. Only when
+                // there is metadata to show; `▾` while expanded, `▸` collapsed.
+                if seg == 0 && num_w >= 2 && self.commit_meta.len() > 1 {
+                    let g = if self.show_meta {
+                        self.config.collapse_symbol.clone()
+                    } else {
+                        self.config.expand_symbol.clone()
+                    };
+                    self.program.screen_mut()
+                        .set_str((x + num_w - 2, y), &g, bg(self.theme.line_number.clone()));
+                }
                 // The commit line, always shown and bold like the file header.
                 let (s, _) = self.slice_h(&r.spans[0].text, self.hscroll as u16, width);
                 self.program.screen_mut()

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1606,15 +1606,15 @@ impl App {
         self.wrap_width(body, Gut::Both)
     }
 
-    /// Display width of the wrap glyph (usually 1).
-    fn wrap_glyph_w(&self) -> u16 {
+    /// Display width of the wrap symbol (usually 1).
+    fn wrap_symbol_w(&self) -> u16 {
         self.width(&self.config.wrap_symbol).max(1)
     }
 
     /// Break-indent width for a row: the display width of its leading spaces,
     /// capped so a continuation line still keeps a few content columns after
-    /// the indent, the wrap glyph, and its trailing space. The `+ 5` reserves
-    /// the glyph width plus five columns: one for the trailing space and four
+    /// the indent, the wrap symbol, and its trailing space. The `+ 5` reserves
+    /// the symbol width plus five columns: one for the trailing space and four
     /// as a minimum of visible content. Tabs were already expanded to spaces
     /// for content rows.
     fn wrap_indent_width(&self, r: &Row, cw: u16) -> u16 {
@@ -1624,18 +1624,18 @@ impl App {
             .flat_map(|s| s.text.chars())
             .take_while(|c| *c == ' ')
             .count() as u16;
-        n.min(cw.saturating_sub(self.wrap_glyph_w() + 5))
+        n.min(cw.saturating_sub(self.wrap_symbol_w() + 5))
     }
 
     /// How far a continuation line's content is pushed right: the break-indent,
-    /// then the wrap glyph and one space (which prefix the wrapped content).
+    /// then the wrap symbol and one space (which prefix the wrapped content).
     fn wrap_prefix_width(&self, r: &Row, cw: u16) -> u16 {
         // Cap so a continuation keeps at least two content columns — enough for
         // one wide (2-cell) grapheme. Otherwise an ultra-narrow pane could give
         // a continuation a single usable column, and a wide cluster placed there
         // would be dropped by the renderer (`slice_fit` can't emit half a
         // cluster). Rendering and mapping both read this, so they stay in step.
-        (self.wrap_indent_width(r, cw) + self.wrap_glyph_w() + 1).min(cw.saturating_sub(2))
+        (self.wrap_indent_width(r, cw) + self.wrap_symbol_w() + 1).min(cw.saturating_sub(2))
     }
 
     /// Visual height (wrapped segments) of a row in the current layout. In split
@@ -3901,7 +3901,7 @@ impl App {
                 return;
             }
             RowKind::Hunk => {
-                // Gutter glyph: a hunk header can always reveal more context
+                // Gutter symbol: a hunk header can always reveal more context
                 // (in a repo source). Skip it in pager mode, where there's no
                 // repo to expand against.
                 if seg == 0 && num_w >= 2 && !matches!(self.source, Source::Stdin) {
@@ -3915,7 +3915,7 @@ impl App {
                 return;
             }
             RowKind::CommitLine => {
-                // Gutter glyph: the commit line folds its metadata. Only when
+                // Gutter symbol: the commit line folds its metadata. Only when
                 // there is metadata to show; `▾` while expanded, `▸` collapsed.
                 if seg == 0 && num_w >= 2 && self.commit_meta.len() > 1 {
                     let g = if self.show_meta {
@@ -3951,7 +3951,7 @@ impl App {
         if seg == 0 {
             self.program.screen_mut().set_str((cx, y), sign, bg(sign_style));
         }
-        // Continuation segments leave the sign column blank; the wrap glyph is
+        // Continuation segments leave the sign column blank; the wrap symbol is
         // drawn as the first indented content char below.
         cx += 1;
 
@@ -3965,7 +3965,7 @@ impl App {
         // Wrapping draws segment `seg` by offsetting the content by whole
         // segment widths, reusing the horizontal-scroll machinery. Continuation
         // segments are indented to match the line's leading whitespace and
-        // prefixed with the wrap glyph and a space (break-indent). Off, it's the
+        // prefixed with the wrap symbol and a space (break-indent). Off, it's the
         // live horizontal scroll.
         let cw = avail.saturating_sub(content_origin);
         // `cw == 0` means the pane is too narrow for any content (all gutter and
@@ -3976,15 +3976,15 @@ impl App {
             let prefix = self.wrap_prefix_width(r, cw);
             let (col_off, draw_indent) = wrap_seg_offset(&r.content, seg, cw, prefix);
             if seg > 0 {
-                // The wrap glyph is the first char of the continuation line, at
+                // The wrap symbol is the first char of the continuation line, at
                 // the break-indent, in the line-number grey, with a space after
                 // it before the wrapped content resumes. Only draw it when the
                 // reserved prefix actually leaves room: on ultra-narrow panes
-                // `wrap_prefix_width` clamps the prefix so tight that the glyph
+                // `wrap_prefix_width` clamps the prefix so tight that the symbol
                 // would overwrite the first content cell (and desync the
                 // input-mapping/highlighting, which key off `prefix`).
                 let indent = self.wrap_indent_width(r, cw);
-                if indent + self.wrap_glyph_w() <= prefix {
+                if indent + self.wrap_symbol_w() <= prefix {
                     let st = bg(self.theme.line_number.clone());
                     self.program.screen_mut().set_str(
                         (content_origin + indent, y),
@@ -4233,7 +4233,7 @@ fn wrap_breaks(content: &[Cell], cw: u16, prefix: u16) -> Vec<u16> {
 /// first display column of content the segment shows (aligned to a
 /// grapheme-cluster boundary) and how far past the content origin it is drawn.
 /// Segment 0 starts at column 0 with no indent; each continuation is indented
-/// by `prefix` (the break-indent plus the wrap glyph and its trailing space).
+/// by `prefix` (the break-indent plus the wrap symbol and its trailing space).
 fn wrap_seg_offset(content: &[Cell], seg: usize, cw: u16, prefix: u16) -> (u16, u16) {
     if seg == 0 || cw == 0 {
         return (0, 0);

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -9,6 +9,7 @@ use std::time::{Duration, Instant};
 
 use regex::{Regex, RegexBuilder};
 
+use uncurses::ansi::mode::Mode;
 use uncurses::buffer::{Bounded, Line, SurfaceMut};
 use uncurses::cell::Cell;
 use uncurses::color::Color;
@@ -836,12 +837,14 @@ pub struct App {
     mascot_pinned: bool,
     /// Timestamps of recent Esc taps, for detecting the triple-tap toggle.
     esc_taps: (u8, Option<Instant>),
-    /// Symbols, measured/clipped once at startup. Config is read once (drift
-    /// has no runtime reload) and terminal width policy is fixed, so these
-    /// never change — computing them per frame would re-measure graphemes on
-    /// hot paths (`wrap_sym_w` feeds every row's height and wrap math).
-    /// `wrap_sym_w` is the wrap symbol's display width; the fold symbols are
-    /// pre-clipped to the two gutter cells they draw into.
+    /// Symbols, measured/clipped once and re-measured only when the terminal's
+    /// width policy changes. Config is read once (drift has no runtime reload),
+    /// so the only thing that moves them is the terminal adopting
+    /// grapheme-cluster mode (DEC 2027) after startup — handled in `handle`.
+    /// Measuring per frame would re-run grapheme measurement on hot paths
+    /// (`wrap_sym_w` feeds every row's height and wrap math). `wrap_sym_w` is
+    /// the wrap symbol's display width; the fold symbols are pre-clipped to the
+    /// two gutter cells they draw into.
     wrap_sym_w: u16,
     expand_sym: String,
     collapse_sym: String,
@@ -902,13 +905,6 @@ impl App {
         let toplevel = crate::git::toplevel();
         let title_dir = toplevel.as_deref().map(abbrev_home);
         let wrap = config.wrap;
-        // Measure the symbols once: config is read only at startup and the
-        // screen's width policy is fixed, so these are constant for the run.
-        let wrap_sym_w = program.screen().str_width(&config.wrap_symbol).max(1);
-        let clip2 = |s: &str| slice_fit(program.screen().grapheme_cells(s), 0, 2).0;
-        let expand_sym = clip2(&config.expand_symbol);
-        let collapse_sym = clip2(&config.collapse_symbol);
-        let context_sym = clip2(&config.context_symbol);
         let mut app = App {
             program,
             config,
@@ -965,11 +961,14 @@ impl App {
             mascot_grab: None,
             mascot_pinned: false,
             esc_taps: (0, None),
-            wrap_sym_w,
-            expand_sym,
-            collapse_sym,
-            context_sym,
+            wrap_sym_w: 1,
+            expand_sym: String::new(),
+            collapse_sym: String::new(),
+            context_sym: String::new(),
         };
+        // Measure the symbols against the current width policy. Re-run later if
+        // the terminal adopts grapheme-cluster mode (DEC 2027) mid-session.
+        app.refresh_symbols();
         app.start();
         Ok(Some(app))
     }
@@ -1625,6 +1624,17 @@ impl App {
         }
         let body = self.program.screen().width().saturating_sub(self.sidebar_w());
         self.wrap_width(body, Gut::Both)
+    }
+
+    /// Measure and clip the configured symbols against the screen's current
+    /// width policy, caching the result. Called once at startup and again if
+    /// the terminal adopts grapheme-cluster mode (DEC 2027) after startup,
+    /// which can change how a multi-codepoint symbol measures.
+    fn refresh_symbols(&mut self) {
+        self.wrap_sym_w = self.width(&self.config.wrap_symbol).max(1);
+        self.expand_sym = self.slice_h(&self.config.expand_symbol, 0, 2).0;
+        self.collapse_sym = self.slice_h(&self.config.collapse_symbol, 0, 2).0;
+        self.context_sym = self.slice_h(&self.config.context_symbol, 0, 2).0;
     }
 
     /// Break-indent width for a row: the display width of its leading spaces,
@@ -2793,6 +2803,12 @@ impl App {
                 self.move_cursor(0);
                 self.scroll_h(0);
             }
+            // The terminal can adopt grapheme-cluster mode (DEC 2027) after
+            // startup; try_read_event's observe_event has already flipped the
+            // screen's width policy by the time this arrives. That changes how a
+            // multi-codepoint symbol measures, so re-measure the cached symbols
+            // against the now-current policy.
+            Event::ModeReport { mode: Mode::UNICODE_CORE, .. } => self.refresh_symbols(),
             _ => {}
         }
         Ok(false)

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -3905,7 +3905,10 @@ impl App {
                 // (in a repo source). Skip it in pager mode, where there's no
                 // repo to expand against.
                 if seg == 0 && num_w >= 2 && !matches!(self.source, Source::Stdin) {
-                    let g = self.config.context_symbol.clone();
+                    // Clip a custom symbol to the two gutter cells before the
+                    // header text so a wide value can't overwrite it.
+                    let sym = self.config.context_symbol.clone();
+                    let (g, _) = self.slice_h(&sym, 0, 2);
                     self.program.screen_mut()
                         .set_str((x + num_w - 2, y), &g, bg(self.theme.line_number.clone()));
                 }
@@ -3916,13 +3919,16 @@ impl App {
             }
             RowKind::CommitLine => {
                 // Gutter symbol: the commit line folds its metadata. Only when
-                // there is metadata to show; `▾` while expanded, `▸` collapsed.
+                // there is metadata to show; the expanded state shows the
+                // collapse symbol, the collapsed state the expand symbol.
                 if seg == 0 && num_w >= 2 && self.commit_meta.len() > 1 {
-                    let g = if self.show_meta {
+                    let sym = if self.show_meta {
                         self.config.collapse_symbol.clone()
                     } else {
                         self.config.expand_symbol.clone()
                     };
+                    // Clip to the two gutter cells before the header text.
+                    let (g, _) = self.slice_h(&sym, 0, 2);
                     self.program.screen_mut()
                         .set_str((x + num_w - 2, y), &g, bg(self.theme.line_number.clone()));
                 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -3905,7 +3905,7 @@ impl App {
                 // (in a repo source). Skip it in pager mode, where there's no
                 // repo to expand against.
                 if seg == 0 && num_w >= 2 && !matches!(self.source, Source::Stdin) {
-                    let g = self.config.expand_symbol.clone();
+                    let g = self.config.context_symbol.clone();
                     self.program.screen_mut()
                         .set_str((x + num_w - 2, y), &g, bg(self.theme.line_number.clone()));
                 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -836,6 +836,16 @@ pub struct App {
     mascot_pinned: bool,
     /// Timestamps of recent Esc taps, for detecting the triple-tap toggle.
     esc_taps: (u8, Option<Instant>),
+    /// Symbols, measured/clipped once at startup. Config is read once (drift
+    /// has no runtime reload) and terminal width policy is fixed, so these
+    /// never change — computing them per frame would re-measure graphemes on
+    /// hot paths (`wrap_sym_w` feeds every row's height and wrap math).
+    /// `wrap_sym_w` is the wrap symbol's display width; the fold symbols are
+    /// pre-clipped to the two gutter cells they draw into.
+    wrap_sym_w: u16,
+    expand_sym: String,
+    collapse_sym: String,
+    context_sym: String,
 }
 
 impl App {
@@ -892,6 +902,13 @@ impl App {
         let toplevel = crate::git::toplevel();
         let title_dir = toplevel.as_deref().map(abbrev_home);
         let wrap = config.wrap;
+        // Measure the symbols once: config is read only at startup and the
+        // screen's width policy is fixed, so these are constant for the run.
+        let wrap_sym_w = program.screen().str_width(&config.wrap_symbol).max(1);
+        let clip2 = |s: &str| slice_fit(program.screen().grapheme_cells(s), 0, 2).0;
+        let expand_sym = clip2(&config.expand_symbol);
+        let collapse_sym = clip2(&config.collapse_symbol);
+        let context_sym = clip2(&config.context_symbol);
         let mut app = App {
             program,
             config,
@@ -948,6 +965,10 @@ impl App {
             mascot_grab: None,
             mascot_pinned: false,
             esc_taps: (0, None),
+            wrap_sym_w,
+            expand_sym,
+            collapse_sym,
+            context_sym,
         };
         app.start();
         Ok(Some(app))
@@ -1606,11 +1627,6 @@ impl App {
         self.wrap_width(body, Gut::Both)
     }
 
-    /// Display width of the wrap symbol (usually 1).
-    fn wrap_symbol_w(&self) -> u16 {
-        self.width(&self.config.wrap_symbol).max(1)
-    }
-
     /// Break-indent width for a row: the display width of its leading spaces,
     /// capped so a continuation line still keeps a few content columns after
     /// the indent, the wrap symbol, and its trailing space. The `+ 5` reserves
@@ -1624,7 +1640,7 @@ impl App {
             .flat_map(|s| s.text.chars())
             .take_while(|c| *c == ' ')
             .count() as u16;
-        n.min(cw.saturating_sub(self.wrap_symbol_w() + 5))
+        n.min(cw.saturating_sub(self.wrap_sym_w + 5))
     }
 
     /// How far a continuation line's content is pushed right: the break-indent,
@@ -1635,7 +1651,7 @@ impl App {
         // a continuation a single usable column, and a wide cluster placed there
         // would be dropped by the renderer (`slice_fit` can't emit half a
         // cluster). Rendering and mapping both read this, so they stay in step.
-        (self.wrap_indent_width(r, cw) + self.wrap_symbol_w() + 1).min(cw.saturating_sub(2))
+        (self.wrap_indent_width(r, cw) + self.wrap_sym_w + 1).min(cw.saturating_sub(2))
     }
 
     /// Visual height (wrapped segments) of a row in the current layout. In split
@@ -3905,12 +3921,10 @@ impl App {
                 // (in a repo source). Skip it in pager mode, where there's no
                 // repo to expand against.
                 if seg == 0 && num_w >= 2 && !matches!(self.source, Source::Stdin) {
-                    // Clip a custom symbol to the two gutter cells before the
-                    // header text so a wide value can't overwrite it.
-                    let sym = self.config.context_symbol.clone();
-                    let (g, _) = self.slice_h(&sym, 0, 2);
+                    // The symbol is pre-clipped to the two gutter cells at
+                    // startup so a wide custom value can't overwrite the header.
                     self.program.screen_mut()
-                        .set_str((x + num_w - 2, y), &g, bg(self.theme.line_number.clone()));
+                        .set_str((x + num_w - 2, y), &self.context_sym, bg(self.theme.line_number.clone()));
                 }
                 let (s, _) = self.slice_h(&r.spans[0].text, self.hscroll as u16, width);
                 self.program.screen_mut()
@@ -3922,15 +3936,14 @@ impl App {
                 // there is metadata to show; the expanded state shows the
                 // collapse symbol, the collapsed state the expand symbol.
                 if seg == 0 && num_w >= 2 && self.commit_meta.len() > 1 {
+                    // Pre-clipped to the two gutter cells at startup.
                     let sym = if self.show_meta {
-                        self.config.collapse_symbol.clone()
+                        &self.collapse_sym
                     } else {
-                        self.config.expand_symbol.clone()
+                        &self.expand_sym
                     };
-                    // Clip to the two gutter cells before the header text.
-                    let (g, _) = self.slice_h(&sym, 0, 2);
                     self.program.screen_mut()
-                        .set_str((x + num_w - 2, y), &g, bg(self.theme.line_number.clone()));
+                        .set_str((x + num_w - 2, y), sym, bg(self.theme.line_number.clone()));
                 }
                 // The commit line, always shown and bold like the file header.
                 let (s, _) = self.slice_h(&r.spans[0].text, self.hscroll as u16, width);
@@ -3990,7 +4003,7 @@ impl App {
                 // would overwrite the first content cell (and desync the
                 // input-mapping/highlighting, which key off `prefix`).
                 let indent = self.wrap_indent_width(r, cw);
-                if indent + self.wrap_symbol_w() <= prefix {
+                if indent + self.wrap_sym_w <= prefix {
                     let st = bg(self.theme.line_number.clone());
                     self.program.screen_mut().set_str(
                         (content_origin + indent, y),


### PR DESCRIPTION
Adds configurable gutter symbols in the (previously blank) line-number gutter of foldable header rows, so it is visible which lines you can expand/collapse. Also standardizes the config vocabulary on `-symbol` (matching delta and Starship).

## The symbols

| Config key | Default | Where it shows |
|---|---|---|
| `context-symbol` | `⋯` | hunk header — reveal more context with `Enter` (repo sources only) |
| `expand-symbol` | `›` | collapsed commit line — expand to show its metadata |
| `collapse-symbol` | `⌄` | expanded commit line — collapse to hide its metadata |
| `wrap-symbol` | `↪` | start of each wrapped continuation line (existing; renamed for consistency) |

All four are configurable via config file or gitconfig, drawn in the line-number grey.

## All symbols in action
The clip below shows every symbol: `⌄` on the expanded commit line + `⋯` on the hunk, then `w` turns on wrapping (`↪`), then `Enter` collapses the commit metadata (`⌄` → `›`).

![symbols.gif](https://github.com/user-attachments/assets/3b1dd64a-960c-40ae-9bcd-920c24baaeda)

## Naming
The four keys use `-symbol` to match **delta** (which ships its own `wrap-symbol`) and **Starship**; the drawing helpers and comments were aligned to "symbol" too. Generic drawn-mark uses of "glyph" (the mascot, key characters, wide graphemes) are left as-is.

## Tests
- 49 unit tests pass; clippy unchanged (5 pre-existing).
- PTY-verified: hunk `⋯` (repo source), commit `⌄`⇄`›` toggle, no hunk symbol in piped mode, single-width alignment for `› ⌄ ⋯`.

## Open review item
Copilot noted the `⋯` marker appears on every repo hunk, even ones with no hidden context left to reveal. Precise per-hunk gating needs per-file line totals drift does not track (and varies per source), so it is left as a general "reveal context" affordance for now — see the review thread for the tradeoff.

## Demo GIF
The repo's `demo/drift.gif` is deferred to avoid a binary-diff clash with the open demo-refresh #26; the symbols will fold into whichever demo render lands last.