### PR TITLE
fix(release): build Linux binaries as static musl

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,9 +34,14 @@ builds:
   - id: cross
     builder: rust
     binary: drift
+    # Linux ships as static musl binaries, not glibc: a glibc build only runs on
+    # a glibc at least as new as the build host's (zig defaults to a recent one),
+    # which broke drift on older enterprise distros (issue #22). Static musl has
+    # no libc floor and runs everywhere, incl. Alpine. mimalloc (see Cargo.toml)
+    # offsets musl's slower allocator. Windows stays gnu (mingw), unaffected.
     targets:
-      - x86_64-unknown-linux-gnu
-      - aarch64-unknown-linux-gnu
+      - x86_64-unknown-linux-musl
+      - aarch64-unknown-linux-musl
       - x86_64-pc-windows-gnu
     flags:
       - --release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,6 +218,7 @@ name = "drift-diff"
 version = "0.0.8"
 dependencies = [
  "clap",
+ "mimalloc",
  "notify",
  "regex",
  "serde",
@@ -236,6 +247,12 @@ dependencies = [
  "regex-automata",
  "regex-syntax",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
 name = "flate2"
@@ -343,6 +360,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,6 +385,15 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -593,6 +628,12 @@ dependencies = [
  "serde",
  "unsafe-libyaml",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,14 @@ toml = "1"
 two-face = { version = "0.5.1", default-features = false, features = ["syntect-fancy"] }
 regex = "1.13.0"
 
+# mimalloc replaces the system allocator on every target except Windows. It
+# markedly cuts CPU time and peak memory when highlighting large diffs, most of
+# all on musl (whose default allocator is slower and holds more memory). It is
+# excluded on Windows only because its C sources do not cross-compile under the
+# windows-gnu (zig) release toolchain.
+[target.'cfg(not(target_os = "windows"))'.dependencies]
+mimalloc = { version = "0.1", default-features = false }
+
 [profile.release]
 opt-level = "z"
 lto = true
@@ -37,8 +45,9 @@ panic = "abort"
 # `cargo binstall` reuses the GoReleaser release archives. Their names mirror
 # the GoReleaser `archives.name_template` (drift_<version>_<os>_<arch>.<ext>),
 # which uses Go-style os/arch rather than Rust target triples, so each target is
-# mapped explicitly. Targets with no entry (musl, 32-bit, ...) have no published
-# binary and fall back to building from source.
+# mapped explicitly. The Linux archives ship a static musl binary, so it is
+# mapped for both the -gnu and -musl host targets (a static binary runs on
+# either). Targets with no entry (32-bit, ...) fall back to building from source.
 [package.metadata.binstall]
 bin-dir = "{ bin }{ binary-ext }"
 
@@ -52,6 +61,12 @@ pkg-url = "{ repo }/releases/download/v{ version }/drift_{ version }_darwin_arm6
 pkg-url = "{ repo }/releases/download/v{ version }/drift_{ version }_linux_amd64.tar.gz"
 
 [package.metadata.binstall.overrides.aarch64-unknown-linux-gnu]
+pkg-url = "{ repo }/releases/download/v{ version }/drift_{ version }_linux_arm64.tar.gz"
+
+[package.metadata.binstall.overrides.x86_64-unknown-linux-musl]
+pkg-url = "{ repo }/releases/download/v{ version }/drift_{ version }_linux_amd64.tar.gz"
+
+[package.metadata.binstall.overrides.aarch64-unknown-linux-musl]
 pkg-url = "{ repo }/releases/download/v{ version }/drift_{ version }_linux_arm64.tar.gz"
 
 [package.metadata.binstall.overrides.x86_64-pc-windows-msvc]

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,13 @@ use clap::Parser;
 use config::Config;
 use git::Source;
 
+// mimalloc cuts CPU time and peak memory when highlighting large diffs, most of
+// all on the static musl release binary. Off on Windows only: its C sources do
+// not cross-compile under the windows-gnu (zig) release toolchain (see Cargo.toml).
+#[cfg(not(target_os = "windows"))]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 /// A standalone git diff pager: browse commit, staged, or working-tree diffs
 /// in a TUI with syntax highlighting, intra-line changes, and live refresh.
 #[derive(Parser, Debug)]


### PR DESCRIPTION
## Problem

The prebuilt Linux binaries are dynamically linked against glibc. zig picks a recent default glibc floor (2.30 in the current toolchain), so the binaries require a glibc **at least that new** and fail to start on older enterprise distros — exactly what #22 reports.

Reproduced on the reporter's distro:

```
$ drift --version        # AlmaLinux 8.10, glibc 2.28
drift: /lib64/libc.so.6: version `GLIBC_2.29' not found (required by drift)
```

## Fix

Build the two Linux release targets as **static musl** (`x86_64/aarch64-unknown-linux-musl`). A static binary has no libc floor and runs on any Linux, including musl-only distros like Alpine.

musl's default allocator is slower and holds more memory (visible when highlighting large diffs), so this also adds **mimalloc** as the global allocator on every target except Windows (its C sources don't cross-compile under the windows-gnu zig toolchain).

No downstream churn: archive names use os/arch, so the npm wrapper, Homebrew, Scoop, AUR, and nfpm packages are unchanged. `binstall` now also maps the `-musl` host targets.

## Validation

Cross-built both arches and ran each binary on real distros (`--version` + a stdin functional check), x86_64 and native arm64:

| Distro (libc) | current (unpinned gnu) | **static musl (this PR)** |
|---|:--:|:--:|
| CentOS 7 (glibc 2.17) | ❌ needs 2.27 | ✅ |
| AlmaLinux 8.10 (glibc 2.28) — *reporter* | ❌ needs 2.29 | ✅ |
| Ubuntu 24.04 (glibc 2.39) | ✅ | ✅ |
| Alpine 3.20 (musl, no glibc) | ❌ no loader | ✅ |

### Allocator (144k-line diff, 24 files; CPU + peak RSS via `wait4`, min-of-9 interleaved, arm64)

| build | CPU median | peak RSS |
|---|--:|--:|
| glibc (system alloc) | 0.698 s | 638 MB |
| musl (system alloc) | 0.888 s | 957 MB |
| **musl + mimalloc (this PR)** | **0.511 s** | **669 MB** |
| glibc + mimalloc | 0.482 s | 668 MB |

mimalloc erases the musl penalty (−42% CPU, −30% RSS vs plain musl) and lands on par with a glibc+mimalloc build. Interactive first-frame latency was identical either way (highlighting is async). mimalloc adds ~113 KB to the binary.

### Size (gzip ≈ download)

Static musl is a wash vs the old glibc binary: ~3.5 MB raw, ~2.0 MB gzipped per arch.

Local checks: `cargo build`/`test` (49 pass)/`clippy` (baseline 5) clean; `goreleaser check` accepts the config; musl and windows-gnu targets both cross-build with the allocator correctly gated.

Fixes: #22
